### PR TITLE
[fix] Fix flaky e2e timezone test by reading date from browser

### DIFF
--- a/ci/apps/tests-e2e.dockerfile
+++ b/ci/apps/tests-e2e.dockerfile
@@ -1,10 +1,5 @@
 FROM mcr.microsoft.com/dotnet/sdk:8.0
 
-# Install timezone data and set timezone
-RUN apt-get update && apt-get install -y tzdata && rm -rf /var/lib/apt/lists/*
-ENV TZ=America/New_York
-RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
-
 WORKDIR /app
 
 COPY code/tests/DarkDeeds.E2eTests/DarkDeeds.E2eTests.sln /app/DarkDeeds.E2eTests.sln

--- a/ci/workflows/test-e2e.sh
+++ b/ci/workflows/test-e2e.sh
@@ -21,9 +21,13 @@ docker network rm dd-test-e2e-network
 
 echo "----------- Starting Selenium Grid..."
 docker network create dd-test-e2e-network
+# TZ defines the browser timezone, which drives the app's "today". Kept non-UTC so the
+# tests actually exercise timezone handling. The test container itself needs no timezone:
+# TimezoneTest reads "today" from the browser, not from the test host clock.
 docker run -d \
   --network dd-test-e2e-network \
   --platform linux/x86_64 \
+  -e TZ=America/New_York \
   --name dd-test-e2e-chrome \
   selenium/standalone-chrome:127.0-20240813
 
@@ -39,7 +43,6 @@ rm -rf ci/results
 docker build -t dd-test-e2e -f ci/apps/tests-e2e.dockerfile . || exit $?
 docker run -t --rm \
   --network dd-test-e2e-network \
-  -e TZ=America/New_York \
   -e ARTIFACTS_PATH='/app/artifacts' \
   -e CONTAINER='true' \
   -e URL="$FE_URL" \

--- a/code/tests/DarkDeeds.E2eTests/Common/DriverLowLevelExtensions.cs
+++ b/code/tests/DarkDeeds.E2eTests/Common/DriverLowLevelExtensions.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using OpenQA.Selenium;
 using OpenQA.Selenium.Remote;
 using OpenQA.Selenium.Support.Extensions;
@@ -92,6 +93,14 @@ public static class DriverLowLevelExtensions
     public static void CreateTab(this RemoteWebDriver driver)
     {
         driver.ExecuteJavaScript("window.open()");
+    }
+
+    public static DateTime GetBrowserDate(this RemoteWebDriver driver)
+    {
+        var date = driver.ExecuteJavaScript<string>(
+            "const d = new Date();" +
+            "return d.getFullYear() + '-' + String(d.getMonth() + 1).padStart(2, '0') + '-' + String(d.getDate()).padStart(2, '0');");
+        return DateTime.ParseExact(date, "yyyy-MM-dd", CultureInfo.InvariantCulture);
     }
 
     private static WebDriverWait Wait(this RemoteWebDriver driver, int timeoutInSeconds = 15)

--- a/code/tests/DarkDeeds.E2eTests/SmokeTests.cs
+++ b/code/tests/DarkDeeds.E2eTests/SmokeTests.cs
@@ -115,13 +115,14 @@ public class SmokeTests(ITestOutputHelper output) : UserLoginTest
     [Fact]
     public Task TimezoneTest()
     {
-#pragma warning disable RS0030
-        var now = DateTime.Now;
-#pragma warning restore RS0030
         var originalTaskText = RandomizeText("timezone task");
-        var taskTextWithDate = $"{now.Month:D2}{now.Day:D2} " + originalTaskText;
         return Test(driver =>
         {
+            // The overview is rendered in the browser's timezone (configured on the Selenium grid),
+            // so "today" must be read from the browser rather than from the test host clock.
+            var now = driver.GetBrowserDate();
+            var taskTextWithDate = $"{now.Month:D2}{now.Day:D2} " + originalTaskText;
+
             var expiredDaysCount = ((int)now.DayOfWeek + 6) % 7;
             var currentExpiredDaysCount = driver.CountElements(X.OverviewPage().CurrentSection().Block(1).Expired());
             Assert.Equal(expiredDaysCount, currentExpiredDaysCount);


### PR DESCRIPTION
TimezoneTest compared the test host clock (DateTime.Now) with the overview rendered in the browser. The Selenium grid ran in UTC while the test container was set to America/New_York, so the daily 02:00 UTC run put them on different calendar days and failed with Expected 1 / Actual 2.

- Set TZ=America/New_York only on the Selenium grid (the user's browser timezone); the test container no longer needs a timezone
- Read "today" from the browser via new GetBrowserDate() instead of host DateTime.Now
- Remove redundant timezone setup (tzdata, ENV TZ, localtime symlink) from tests-e2e.dockerfile; base SDK image already ships tzdata
- Drop the RS0030 (banned DateTime.Now) suppression