### PR TITLE
[chore] Run daily integration tests against master images

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
   pull_request:
   push:
-    branches: [ staging ]
+    branches: [ staging, master ]
 
 env:
   REGISTRY: ghcr.io

--- a/.github/workflows/tests-integration.yml
+++ b/.github/workflows/tests-integration.yml
@@ -12,12 +12,12 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-      - name: Deploy staging with latest version
+      - name: Deploy staging with master version
         id: operation
         run: |
           OUTPUT=$(./ci/workflows/drone-job-trigger.sh \
             "deploy-staging" \
-            "latest" \
+            "master" \
             "${{ github.ref_name }}" \
             "${{ secrets.DRONE_SERVER }}" \
             "${{ secrets.DRONE_TOKEN }}" \


### PR DESCRIPTION
- Build and push Docker images on push to master (tagged `master`)
- Switch tests-integration deploy from `latest` to `master` so the daily e2e/load run validates master instead of the released image