### PR TITLE
[feat] Add toast auto-dismiss with progress bar

### DIFF
--- a/code/frontend/src/tasks/hooks/useTasksSynchronization.ts
+++ b/code/frontend/src/tasks/hooks/useTasksSynchronization.ts
@@ -82,6 +82,7 @@ export function useTasksSynchronization(): Output {
                     addToast({
                         text: `Failed to save ${notSaved} tasks`,
                         category: 'task-save-failed',
+                        autoDismissMs: 6000,
                     }),
                 )
             }

--- a/code/frontend/src/toasts/components/Toast.module.css
+++ b/code/frontend/src/toasts/components/Toast.module.css
@@ -10,3 +10,30 @@
 .show {
     animation: show 0.2s linear;
 }
+
+.toast {
+    position: relative;
+    overflow: hidden;
+}
+
+.progress {
+    position: absolute;
+    left: 0;
+    bottom: 0;
+    width: 100%;
+    height: 3px;
+    background-color: rgba(255, 255, 255, 0.6);
+    transform-origin: left;
+    animation-name: progress-shrink;
+    animation-timing-function: linear;
+    animation-fill-mode: forwards;
+}
+
+@keyframes progress-shrink {
+    from {
+        transform: scaleX(1);
+    }
+    to {
+        transform: scaleX(0);
+    }
+}

--- a/code/frontend/src/toasts/components/Toast.tsx
+++ b/code/frontend/src/toasts/components/Toast.tsx
@@ -1,4 +1,5 @@
 import clsx from 'clsx'
+import { useEffect } from 'react'
 import { ToastModel } from '../models/ToastModel'
 import styles from './Toast.module.css'
 
@@ -8,9 +9,23 @@ interface Props {
 }
 
 function Toast({ toast, onClose }: Props) {
+    const { id, autoDismissMs, counter } = toast
+
+    // Restart the auto-dismiss timer whenever the toast is re-triggered (counter bumps when a
+    // same-category toast is stacked), so an active toast does not vanish while related events
+    // keep arriving.
+    useEffect(() => {
+        if (autoDismissMs === null) {
+            return
+        }
+
+        const timeout = setTimeout(() => onClose(id), autoDismissMs)
+        return () => clearTimeout(timeout)
+    }, [id, autoDismissMs, onClose, counter])
+
     return (
         <div
-            className={clsx('toast show align-items-center border-0', styles.show, {
+            className={clsx('toast show align-items-center border-0', styles.toast, styles.show, {
                 'bg-primary': toast.type === 'primary',
                 'bg-success': toast.type === 'success',
                 'bg-info': toast.type === 'info',
@@ -28,6 +43,9 @@ function Toast({ toast, onClose }: Props) {
                     onClick={() => onClose(toast.id)}
                 ></button>
             </div>
+            {autoDismissMs !== null && (
+                <div key={counter} className={styles.progress} style={{ animationDuration: `${autoDismissMs}ms` }} />
+            )}
         </div>
     )
 }

--- a/code/frontend/src/toasts/models/AddToastModel.ts
+++ b/code/frontend/src/toasts/models/AddToastModel.ts
@@ -2,4 +2,5 @@ export interface AddToastModel {
     type?: 'info' | 'success' | 'primary'
     text: string
     category?: 'task-save-failed' | 'task-save-conflict'
+    autoDismissMs?: number
 }

--- a/code/frontend/src/toasts/models/ToastModel.ts
+++ b/code/frontend/src/toasts/models/ToastModel.ts
@@ -4,4 +4,5 @@ export interface ToastModel {
     text: string
     category: '' | 'task-save-failed' | 'task-save-conflict'
     counter: number
+    autoDismissMs: number | null
 }

--- a/code/frontend/src/toasts/redux/toasts-slice.ts
+++ b/code/frontend/src/toasts/redux/toasts-slice.ts
@@ -30,6 +30,7 @@ export const toastsSlice = createSlice({
                 text: action.payload.text,
                 category: action.payload.category ?? '',
                 counter: 0,
+                autoDismissMs: action.payload.autoDismissMs ?? null,
             })
         },
         removeToast: (state, action: PayloadAction<string>) => {

--- a/code/frontend/tests/redux/toasts-slice.test.ts
+++ b/code/frontend/tests/redux/toasts-slice.test.ts
@@ -1,0 +1,27 @@
+import { expect, test } from 'vitest'
+import toastsReducer, { addToast, ToastsState } from '../../src/toasts/redux/toasts-slice'
+
+function createState(): ToastsState {
+    return { toasts: [] }
+}
+
+test('[addToast] defaults autoDismissMs to null when not provided', () => {
+    const next = toastsReducer(createState(), addToast({ text: 'Hello' }))
+
+    expect(next.toasts).toHaveLength(1)
+    expect(next.toasts[0].autoDismissMs).toBeNull()
+})
+
+test('[addToast] keeps the provided autoDismissMs', () => {
+    const next = toastsReducer(createState(), addToast({ text: 'Session expired', autoDismissMs: 6000 }))
+
+    expect(next.toasts[0].autoDismissMs).toBe(6000)
+})
+
+test('[addToast] dedups by category and bumps the counter', () => {
+    let state = toastsReducer(createState(), addToast({ text: 'Failed', category: 'task-save-failed' }))
+    state = toastsReducer(state, addToast({ text: 'Failed', category: 'task-save-failed' }))
+
+    expect(state.toasts).toHaveLength(1)
+    expect(state.toasts[0].counter).toBe(1)
+})


### PR DESCRIPTION
Adds optional auto-dismiss support to toasts and uses it for the "task save failed" notification.

### What changed
- Add an optional `autoDismissMs` field to `AddToastModel` / `ToastModel` (and default it to `null` in the reducer).
- When set, `Toast` schedules its own removal after the delay and renders a shrinking progress bar showing the remaining time.
- The timer restarts whenever a same-category toast is re-triggered (the `counter` bumps), so an active toast isn't cut short while related events keep arriving.
- Use it for the **"Failed to save N tasks"** toast (`autoDismissMs: 6000`).

### Tests
- New `tests/redux/toasts-slice.test.ts`: defaults `autoDismissMs` to `null`, keeps a provided value, and dedups by category bumping the counter.

Verified: `npm run build`, `npm run fmt:check`, `npm run test:run` all pass