### PR TITLE
[feat] Support date ranges in task quick-input to create many tasks

### DIFF
--- a/code/backend/DD.ServiceTask.Domain/Exceptions/ServiceException.cs
+++ b/code/backend/DD.ServiceTask.Domain/Exceptions/ServiceException.cs
@@ -21,4 +21,9 @@ public class ServiceException : Exception
     {
         return new ServiceException($"{name} is invalid for this operation");
     }
+
+    public static ServiceException InvalidDateRange(int maxDays)
+    {
+        return new ServiceException($"Date range is invalid or exceeds the maximum of {maxDays} days");
+    }
 }

--- a/code/backend/DD.ServiceTask.Domain/Services/RecurrenceCreatorService.cs
+++ b/code/backend/DD.ServiceTask.Domain/Services/RecurrenceCreatorService.cs
@@ -177,7 +177,7 @@ public class RecurrenceCreatorService(
 
     private TaskEntity CreateTaskFromRecurrence(PlannedRecurrenceEntity plannedRecurrence, DateTime date)
     {
-        var dto = taskParserService.ParseTask(plannedRecurrence.Task, ignoreDate: true);
+        var dto = taskParserService.ParseTaskTemplate(plannedRecurrence.Task);
         var task = dto.ToEntity();
         task.Date = date;
         task.UserId = plannedRecurrence.UserId;

--- a/code/backend/DD.ServiceTask.Domain/Services/TaskParserService.cs
+++ b/code/backend/DD.ServiceTask.Domain/Services/TaskParserService.cs
@@ -1,36 +1,132 @@
 using System.Globalization;
 using System.Text.RegularExpressions;
+using DD.ServiceTask.Domain.Exceptions;
 using DD.Shared.Details.Abstractions.Dto;
 
 namespace DD.ServiceTask.Domain.Services;
 
 public interface ITaskParserService
 {
-    TaskDto ParseTask(string task, bool ignoreDate = false);
+    IReadOnlyList<TaskDto> ParseTasks(string task);
+
+    TaskDto ParseTaskTemplate(string task);
 }
 
 public class TaskParserService(IDateService dateService) : ITaskParserService
 {
-    public TaskDto ParseTask(string task, bool ignoreDate = false)
-    {
-        var taskDto = new TaskDto();
-        int year = 0, month = 0, day = 0, dayAdjustment = 0;
-        var withDate = false;
+    private const int MinRangeDays = 2;
+    private const int MaxRangeDays = 31;
 
-        if (!ignoreDate)
-            task = ParseDate(task, out year, out month, out day, out withDate, out dayAdjustment);
+    public IReadOnlyList<TaskDto> ParseTasks(string task)
+    {
+        if (TryParseDateRange(task, out var startDate, out var endDate, out var remaining))
+        {
+            ValidateRange(startDate, endDate);
+
+            var template = ParseTaskTemplate(remaining);
+            var tasks = new List<TaskDto>();
+            for (var date = startDate; date <= endDate; date = date.AddDays(1))
+                tasks.Add(CloneWithDate(template, date));
+
+            return tasks;
+        }
+
+        return [ParseSingle(task)];
+    }
+
+    // Parses a dateless task template: time + flags + title only, without any date.
+    public TaskDto ParseTaskTemplate(string task)
+    {
         task = ParseTime(task, out var hour, out var minutes, out var withTime);
         task = ParseFlags(task, out var isProbable, out var type);
 
-        taskDto.Title = task;
-        taskDto.Type = type;
-        taskDto.IsProbable = isProbable;
-        if (withDate)
-            taskDto.Date = CreateDateTime(year, month, day, dayAdjustment);
+        var taskDto = new TaskDto
+        {
+            Title = task,
+            Type = type,
+            IsProbable = isProbable,
+        };
         if (withTime)
             taskDto.Time = hour * 60 + minutes;
 
         return taskDto;
+    }
+
+    private TaskDto ParseSingle(string task)
+    {
+        task = ParseDate(task, out var year, out var month, out var day, out var withDate, out var dayAdjustment);
+
+        var taskDto = ParseTaskTemplate(task);
+        if (withDate)
+            taskDto.Date = CreateDateTime(year, month, day, dayAdjustment);
+
+        return taskDto;
+    }
+
+    private bool TryParseDateRange(string task, out DateTime startDate, out DateTime endDate, out string remaining)
+    {
+        var rangeRx = new Regex(@"^(\d{8}|\d{4})-(\d{8}|\d{4})\s");
+        var match = rangeRx.Match(task);
+
+        startDate = default;
+        endDate = default;
+        remaining = task;
+
+        if (!match.Success)
+            return false;
+
+        ParseStringDate(match.Groups[1].Value, out var startYear, out var startMonth, out var startDay);
+        ParseStringDate(match.Groups[2].Value, out var endYear, out var endMonth, out var endDay);
+
+        startDate = CreateDateTime(startYear, startMonth, startDay, 0);
+        endDate = CreateDateTime(endYear, endMonth, endDay, 0);
+        remaining = task[match.Length..];
+        return true;
+    }
+
+    // Parses a numeric date token in either MMDD (current year) or YYYYMMDD form.
+    // Shared by the single-date path (ParseDate) and the date-range path (TryParseDateRange).
+    private void ParseStringDate(string token, out int year, out int month, out int day)
+    {
+        if (token.Length == 8)
+        {
+            year = int.Parse(token[..4], CultureInfo.InvariantCulture);
+            month = int.Parse(token[4..6], CultureInfo.InvariantCulture);
+            day = int.Parse(token[6..8], CultureInfo.InvariantCulture);
+        }
+        else
+        {
+            year = dateService.Today.Year;
+            month = int.Parse(token[..2], CultureInfo.InvariantCulture);
+            day = int.Parse(token[2..4], CultureInfo.InvariantCulture);
+        }
+    }
+
+    private static void ValidateRange(DateTime startDate, DateTime endDate)
+    {
+        // A range must span at least two days (i.e. produce at least two tasks) and at most
+        // MaxRangeDays. A reversed range yields a negative count, which is also below MinRangeDays.
+        var dayCount = (endDate - startDate).Days + 1;
+        if (dayCount is < MinRangeDays or > MaxRangeDays)
+            throw ServiceException.InvalidDateRange(MaxRangeDays);
+    }
+
+    private static TaskDto CloneWithDate(TaskDto template, DateTime date)
+    {
+        return new TaskDto
+        {
+            Id = template.Id,
+            Date = date,
+            Time = template.Time,
+            Title = template.Title,
+            Order = template.Order,
+            Completed = template.Completed,
+            IsProbable = template.IsProbable,
+            Deleted = template.Deleted,
+            Type = template.Type,
+            Version = template.Version,
+            Uid = template.Uid,
+        };
     }
 
     private static string ParseFlags(string task, out bool isProbable, out TaskTypeDto type)
@@ -127,7 +223,6 @@ public class TaskParserService(IDateService dateService) : ITaskParserService
         var dateRx = new Regex(@"^\d{4}\s");
         var todayShiftRx = new Regex(@"^!+\s");
         var weekShiftRx = new Regex(@"^![1-7]\s");
-        var date = string.Empty;
         year = 0;
         month = 0;
         day = 0;
@@ -136,15 +231,15 @@ public class TaskParserService(IDateService dateService) : ITaskParserService
 
         if (dateWithYearRx.IsMatch(task))
         {
-            date = task[4..8];
-            year = int.Parse(task[..4], CultureInfo.InvariantCulture);
+            ParseStringDate(task[..8], out year, out month, out day);
             task = task[9..];
+            withDate = true;
         }
         else if (dateRx.IsMatch(task))
         {
-            date = task[..4];
-            year = dateService.Today.Year;
+            ParseStringDate(task[..4], out year, out month, out day);
             task = task[5..];
+            withDate = true;
         }
         else if (todayShiftRx.IsMatch(task))
         {
@@ -160,13 +255,6 @@ public class TaskParserService(IDateService dateService) : ITaskParserService
             year = dateService.Today.Year;
             month = dateService.Today.Month;
             day = dateService.Today.Day;
-            withDate = true;
-        }
-
-        if (!string.IsNullOrEmpty(date))
-        {
-            month = int.Parse(date[..2], CultureInfo.InvariantCulture);
-            day = int.Parse(date[2..4], CultureInfo.InvariantCulture);
             withDate = true;
         }
 

--- a/code/backend/DD.Shared.Details.Abstractions/ITaskServiceApp.cs
+++ b/code/backend/DD.Shared.Details.Abstractions/ITaskServiceApp.cs
@@ -10,5 +10,5 @@ public interface ITaskServiceApp
 
     Task<IEnumerable<TaskDto>> UpdateTasksAsync(ICollection<TaskUpdateDto> updates, string userId, string? clientId);
 
-    Task<TaskDto> ParseTask(string text);
+    Task<IReadOnlyList<TaskDto>> ParseTasks(string text);
 }

--- a/code/backend/DD.Shared.Details/Services/TaskServiceApp.cs
+++ b/code/backend/DD.Shared.Details/Services/TaskServiceApp.cs
@@ -24,8 +24,8 @@ public class TaskServiceApp(
         return taskService.UpdateTasksAsync(updates, userId, clientId);
     }
 
-    public Task<TaskDto> ParseTask(string text)
+    public Task<IReadOnlyList<TaskDto>> ParseTasks(string text)
     {
-        return Task.FromResult(taskParserService.ParseTask(text));
+        return Task.FromResult(taskParserService.ParseTasks(text));
     }
 }

--- a/code/backend/DD.TelegramClient.Domain/Models/Commands/CreateTaskCommand.cs
+++ b/code/backend/DD.TelegramClient.Domain/Models/Commands/CreateTaskCommand.cs
@@ -1,10 +1,8 @@
-using DD.Shared.Details.Abstractions.Dto;
-
 namespace DD.TelegramClient.Domain.Models.Commands;
 
-public class CreateTaskCommand(TaskDto task) : BotCommand
+public class CreateTaskCommand(string text) : BotCommand
 {
-    public TaskDto Task { get; } = task;
+    public string Text { get; } = text;
 
     public override string ToString()
     {

--- a/code/backend/DD.TelegramClient.Domain/Services/BotCommandParserService.cs
+++ b/code/backend/DD.TelegramClient.Domain/Services/BotCommandParserService.cs
@@ -1,4 +1,3 @@
-using DD.Shared.Details.Abstractions;
 using DD.TelegramClient.Domain.Models.Commands;
 
 namespace DD.TelegramClient.Domain.Services;
@@ -10,8 +9,7 @@ public interface IBotCommandParserService
 
 public class BotCommandParserService(
     ITelegramService telegramService,
-    IDateService dateService,
-    ITaskServiceApp taskServiceApp)
+    IDateService dateService)
     : IBotCommandParserService
 {
     private const string TodoCommand = "/todo";
@@ -31,7 +29,7 @@ public class BotCommandParserService(
 
         return command.StartsWith('/')
             ? null
-            : new CreateTaskCommand(await taskServiceApp.ParseTask(command));
+            : new CreateTaskCommand(command);
     }
 
     private static bool CheckAndTrimCommand(string command, string text, out string args)

--- a/code/backend/DD.TelegramClient.Domain/Services/CommandProcessor/CreateTaskCommandProcessor.cs
+++ b/code/backend/DD.TelegramClient.Domain/Services/CommandProcessor/CreateTaskCommandProcessor.cs
@@ -21,8 +21,14 @@ public class CreateTaskCommandProcessor(
     protected override async Task ProcessCoreAsync(CreateTaskCommand command)
     {
         var userId = await telegramService.GetUserId(command.UserChatId);
-        command.Task.Uid = Guid.NewGuid().ToString();
-        await taskServiceApp.SaveTasksAsync([command.Task], userId, clientId: null);
-        await _botSendMessageService.SendTextAsync(command.UserChatId, "Task created");
+        var tasks = await taskServiceApp.ParseTasks(command.Text);
+
+        foreach (var task in tasks)
+            task.Uid = Guid.NewGuid().ToString();
+
+        await taskServiceApp.SaveTasksAsync([.. tasks], userId, clientId: null);
+        await _botSendMessageService.SendTextAsync(
+            command.UserChatId,
+            tasks.Count == 1 ? "Task created" : $"{tasks.Count} tasks created");
     }
 }

--- a/code/backend/DD.Tests.Unit/ServiceTask/Services/RecurrenceCreatorServiceTests/RecurrenceCreatorServiceTest.Base.cs
+++ b/code/backend/DD.Tests.Unit/ServiceTask/Services/RecurrenceCreatorServiceTests/RecurrenceCreatorServiceTest.Base.cs
@@ -28,7 +28,7 @@ public partial class RecurrenceCreatorServiceTest : BaseTest
         _specFactoryMock.Setup(x => x.Create<IPlannedRecurrenceSpecification, PlannedRecurrenceEntity>()).Returns(_plannedRecurrenceSpecMock.Object);
 
         _plannedRecurrenceRepoMock = MocksCreator.RepoRecurrence(values);
-        _taskParserServiceMock.Setup(x => x.ParseTask(It.IsAny<string>(), It.IsAny<bool>())).Returns(new TaskDto { Title = "Task" });
+        _taskParserServiceMock.Setup(x => x.ParseTaskTemplate(It.IsAny<string>())).Returns(new TaskDto { Title = "Task" });
         return new(
             _taskRepoMock.Object,
             _plannedRecurrenceRepoMock.Object,

--- a/code/backend/DD.Tests.Unit/ServiceTask/Services/TaskParserServiceTest.cs
+++ b/code/backend/DD.Tests.Unit/ServiceTask/Services/TaskParserServiceTest.cs
@@ -1,3 +1,4 @@
+using DD.ServiceTask.Domain.Exceptions;
 using DD.ServiceTask.Domain.Services;
 using DD.Shared.Details.Abstractions.Dto;
 using Moq;
@@ -11,11 +12,11 @@ public class TaskParserServiceTest : BaseTest
 
     // #1
     [Fact]
-    public void ParseTask_ReturnTaskWithNoDateAndNoTime()
+    public void ParseTasks_ReturnTaskWithNoDateAndNoTime()
     {
         var service = new TaskParserService(DateServiceMock());
 
-        var result = service.ParseTask("Test!");
+        var result = service.ParseTasks("Test!").Single();
 
         Assert.Equal("Test!", result.Title);
         Assert.Equal(TaskTypeDto.Simple, result.Type);
@@ -25,11 +26,11 @@ public class TaskParserServiceTest : BaseTest
 
     // #2
     [Fact]
-    public void ParseTask_ReturnTaskWithDateAndNoTime()
+    public void ParseTasks_ReturnTaskWithDateAndNoTime()
     {
         var service = new TaskParserService(DateServiceMock());
 
-        var result = service.ParseTask("1231 Test!");
+        var result = service.ParseTasks("1231 Test!").Single();
 
         Assert.Equal("Test!", result.Title);
         Assert.Equal(TaskTypeDto.Simple, result.Type);
@@ -39,11 +40,11 @@ public class TaskParserServiceTest : BaseTest
 
     // #3
     [Fact]
-    public void ParseTask_ReturnTaskWithDateAndNoTime_NotWorkingWithoutSpace()
+    public void ParseTasks_ReturnTaskWithDateAndNoTime_NotWorkingWithoutSpace()
     {
         var service = new TaskParserService(DateServiceMock());
 
-        var result = service.ParseTask("0101Test!!!");
+        var result = service.ParseTasks("0101Test!!!").Single();
 
         Assert.Equal("0101Test!!!", result.Title);
         Assert.Equal(TaskTypeDto.Simple, result.Type);
@@ -53,11 +54,11 @@ public class TaskParserServiceTest : BaseTest
 
     // #4
     [Fact]
-    public void ParseTask_ReturnTaskWithDateAndTime()
+    public void ParseTasks_ReturnTaskWithDateAndTime()
     {
         var service = new TaskParserService(DateServiceMock());
 
-        var result = service.ParseTask("1231 2359 Test!");
+        var result = service.ParseTasks("1231 2359 Test!").Single();
 
         Assert.Equal("Test!", result.Title);
         Assert.Equal(TaskTypeDto.Simple, result.Type);
@@ -67,11 +68,11 @@ public class TaskParserServiceTest : BaseTest
 
     // #5
     [Fact]
-    public void ParseTask_ReturnTaskWithDateAndTime_NotWorkingWithoutSpace()
+    public void ParseTasks_ReturnTaskWithDateAndTime_NotWorkingWithoutSpace()
     {
         var service = new TaskParserService(DateServiceMock());
 
-        var result = service.ParseTask("0101 0101Test!!!");
+        var result = service.ParseTasks("0101 0101Test!!!").Single();
 
         Assert.Equal("0101Test!!!", result.Title);
         Assert.Equal(TaskTypeDto.Simple, result.Type);
@@ -81,11 +82,11 @@ public class TaskParserServiceTest : BaseTest
 
     // #6
     [Fact]
-    public void ParseTask_ReturnTaskWithDateAndNoTimeWithYear()
+    public void ParseTasks_ReturnTaskWithDateAndNoTimeWithYear()
     {
         var service = new TaskParserService(DateServiceMock());
 
-        var result = service.ParseTask("20170101 Test");
+        var result = service.ParseTasks("20170101 Test").Single();
 
         Assert.Equal("Test", result.Title);
         Assert.Equal(TaskTypeDto.Simple, result.Type);
@@ -95,11 +96,11 @@ public class TaskParserServiceTest : BaseTest
 
     // #7
     [Fact]
-    public void ParseTask_ReturnProbableTask()
+    public void ParseTasks_ReturnProbableTask()
     {
         var service = new TaskParserService(DateServiceMock());
 
-        var result = service.ParseTask("Test! ?");
+        var result = service.ParseTasks("Test! ?").Single();
 
         Assert.Equal("Test!", result.Title);
         Assert.True(result.IsProbable);
@@ -109,11 +110,11 @@ public class TaskParserServiceTest : BaseTest
 
     // #8
     [Fact]
-    public void ParseTask_ReturnAdditionalTaskWithDate()
+    public void ParseTasks_ReturnAdditionalTaskWithDate()
     {
         var service = new TaskParserService(DateServiceMock());
 
-        var result = service.ParseTask("0220 Test !");
+        var result = service.ParseTasks("0220 Test !").Single();
 
         Assert.Equal("Test", result.Title);
         Assert.Equal(TaskTypeDto.Additional, result.Type);
@@ -123,11 +124,11 @@ public class TaskParserServiceTest : BaseTest
 
     // #9
     [Fact]
-    public void ParseTask_ReturnAdditionalTaskWithDateAndTime()
+    public void ParseTasks_ReturnAdditionalTaskWithDateAndTime()
     {
         var service = new TaskParserService(DateServiceMock());
 
-        var result = service.ParseTask("20150220 2359 Test !");
+        var result = service.ParseTasks("20150220 2359 Test !").Single();
 
         Assert.Equal("Test", result.Title);
         Assert.Equal(TaskTypeDto.Additional, result.Type);
@@ -137,11 +138,11 @@ public class TaskParserServiceTest : BaseTest
 
     // #10
     [Fact]
-    public void ParseTask_AdditionalAndProbable()
+    public void ParseTasks_AdditionalAndProbable()
     {
         var service = new TaskParserService(DateServiceMock());
 
-        var result = service.ParseTask("Test !?");
+        var result = service.ParseTasks("Test !?").Single();
 
         Assert.Equal("Test", result.Title);
         Assert.Equal(TaskTypeDto.Additional, result.Type);
@@ -152,11 +153,11 @@ public class TaskParserServiceTest : BaseTest
 
     // #10.1
     [Fact]
-    public void ParseTask_ProbableAndAdditional()
+    public void ParseTasks_ProbableAndAdditional()
     {
         var service = new TaskParserService(DateServiceMock());
 
-        var result = service.ParseTask("Test ?!");
+        var result = service.ParseTasks("Test ?!").Single();
 
         Assert.Equal("Test", result.Title);
         Assert.Equal(TaskTypeDto.Additional, result.Type);
@@ -167,11 +168,11 @@ public class TaskParserServiceTest : BaseTest
 
     // #11
     [Fact]
-    public void ParseTask_ReturnTodayTaskThroughExclamationMark()
+    public void ParseTasks_ReturnTodayTaskThroughExclamationMark()
     {
         var service = new TaskParserService(DateServiceMock());
 
-        var result = service.ParseTask("! Test");
+        var result = service.ParseTasks("! Test").Single();
 
         Assert.Equal("Test", result.Title);
         Assert.Equal(TaskTypeDto.Simple, result.Type);
@@ -181,11 +182,11 @@ public class TaskParserServiceTest : BaseTest
 
     // #12
     [Fact]
-    public void ParseTask_ReturnTomorrowTaskThroughExclamationMark()
+    public void ParseTasks_ReturnTomorrowTaskThroughExclamationMark()
     {
         var service = new TaskParserService(DateServiceMock());
 
-        var result = service.ParseTask("!! Test");
+        var result = service.ParseTasks("!! Test").Single();
 
         Assert.Equal("Test", result.Title);
         Assert.Equal(TaskTypeDto.Simple, result.Type);
@@ -195,11 +196,11 @@ public class TaskParserServiceTest : BaseTest
 
     // #13
     [Fact]
-    public void ParseTask_ReturnDayAfterAfterTomorrowTaskThroughExclamationMark()
+    public void ParseTasks_ReturnDayAfterAfterTomorrowTaskThroughExclamationMark()
     {
         var service = new TaskParserService(DateServiceMock());
 
-        var result = service.ParseTask("!!!! Test");
+        var result = service.ParseTasks("!!!! Test").Single();
 
         Assert.Equal("Test", result.Title);
         Assert.Equal(TaskTypeDto.Simple, result.Type);
@@ -209,11 +210,11 @@ public class TaskParserServiceTest : BaseTest
 
     // #14
     [Fact]
-    public void ParseTask_ReturnDayAfterTomorrowNextMonthTaskThroughExclamationMark()
+    public void ParseTasks_ReturnDayAfterTomorrowNextMonthTaskThroughExclamationMark()
     {
         var service = new TaskParserService(DateServiceMock(2019, 1, 31));
 
-        var result = service.ParseTask("!!! Test");
+        var result = service.ParseTasks("!!! Test").Single();
 
         Assert.Equal("Test", result.Title);
         Assert.Equal(TaskTypeDto.Simple, result.Type);
@@ -223,11 +224,11 @@ public class TaskParserServiceTest : BaseTest
 
     // #15
     [Fact]
-    public void ParseTask_ReturnNextMondayTaskThroughExclamationMark()
+    public void ParseTasks_ReturnNextMondayTaskThroughExclamationMark()
     {
         var service = new TaskParserService(DateServiceMock(2019, 7, 28));
 
-        var result = service.ParseTask("!1 Test");
+        var result = service.ParseTasks("!1 Test").Single();
 
         Assert.Equal("Test", result.Title);
         Assert.Equal(TaskTypeDto.Simple, result.Type);
@@ -237,11 +238,11 @@ public class TaskParserServiceTest : BaseTest
 
     // #16
     [Fact]
-    public void ParseTask_ReturnNextWednesdayTaskThroughExclamationMark()
+    public void ParseTasks_ReturnNextWednesdayTaskThroughExclamationMark()
     {
         var service = new TaskParserService(DateServiceMock(2019, 7, 28));
 
-        var result = service.ParseTask("!3 Test");
+        var result = service.ParseTasks("!3 Test").Single();
 
         Assert.Equal("Test", result.Title);
         Assert.Equal(TaskTypeDto.Simple, result.Type);
@@ -251,11 +252,11 @@ public class TaskParserServiceTest : BaseTest
 
     // #17
     [Fact]
-    public void ParseTask_ReturnNextFridayTaskThroughExclamationMark()
+    public void ParseTasks_ReturnNextFridayTaskThroughExclamationMark()
     {
         var service = new TaskParserService(DateServiceMock(2019, 7, 28));
 
-        var result = service.ParseTask("!5 Test");
+        var result = service.ParseTasks("!5 Test").Single();
 
         Assert.Equal("Test", result.Title);
         Assert.Equal(TaskTypeDto.Simple, result.Type);
@@ -265,22 +266,22 @@ public class TaskParserServiceTest : BaseTest
 
     // #18
     [Fact]
-    public void ParseTask_ExclamationMark11IsNotWeekShiftPattern()
+    public void ParseTasks_ExclamationMark11IsNotWeekShiftPattern()
     {
         var service = new TaskParserService(DateServiceMock());
 
-        var result = service.ParseTask("!11 Test");
+        var result = service.ParseTasks("!11 Test").Single();
 
         Assert.Equal("!11 Test", result.Title);
     }
 
     // #19
     [Fact]
-    public void ParseTask_DateWithExclamation()
+    public void ParseTasks_DateWithExclamation()
     {
         var service = new TaskParserService(DateServiceMock());
 
-        var result = service.ParseTask("1231! Test");
+        var result = service.ParseTasks("1231! Test").Single();
 
         Assert.Equal("1231! Test", result.Title);
         Assert.Equal(TaskTypeDto.Simple, result.Type);
@@ -290,11 +291,11 @@ public class TaskParserServiceTest : BaseTest
 
     // #20
     [Fact]
-    public void ParseTask_ReturnRoutineTaskWithDate()
+    public void ParseTasks_ReturnRoutineTaskWithDate()
     {
         var service = new TaskParserService(DateServiceMock());
 
-        var result = service.ParseTask("0220 Test *");
+        var result = service.ParseTasks("0220 Test *").Single();
 
         Assert.Equal("Test", result.Title);
         Assert.Equal(TaskTypeDto.Routine, result.Type);
@@ -304,11 +305,11 @@ public class TaskParserServiceTest : BaseTest
 
     // #21
     [Fact]
-    public void ParseTask_ReturnRoutineTaskWithDateAndTime()
+    public void ParseTasks_ReturnRoutineTaskWithDateAndTime()
     {
         var service = new TaskParserService(DateServiceMock());
 
-        var result = service.ParseTask("20150220 2359 Test *");
+        var result = service.ParseTasks("20150220 2359 Test *").Single();
 
         Assert.Equal("Test", result.Title);
         Assert.Equal(TaskTypeDto.Routine, result.Type);
@@ -318,11 +319,11 @@ public class TaskParserServiceTest : BaseTest
 
     // #22
     [Fact]
-    public void ParseTask_RoutineAndProbable()
+    public void ParseTasks_RoutineAndProbable()
     {
         var service = new TaskParserService(DateServiceMock());
 
-        var result = service.ParseTask("Test *?");
+        var result = service.ParseTasks("Test *?").Single();
 
         Assert.Equal("Test", result.Title);
         Assert.Equal(TaskTypeDto.Routine, result.Type);
@@ -333,11 +334,11 @@ public class TaskParserServiceTest : BaseTest
 
     // #22.1
     [Fact]
-    public void ParseTask_ProbableAndRoutine()
+    public void ParseTasks_ProbableAndRoutine()
     {
         var service = new TaskParserService(DateServiceMock());
 
-        var result = service.ParseTask("Test ?*");
+        var result = service.ParseTasks("Test ?*").Single();
 
         Assert.Equal("Test", result.Title);
         Assert.Equal(TaskTypeDto.Routine, result.Type);
@@ -348,11 +349,11 @@ public class TaskParserServiceTest : BaseTest
 
     // #23
     [Fact]
-    public void ParseTask_RoutineAndAdditional()
+    public void ParseTasks_RoutineAndAdditional()
     {
         var service = new TaskParserService(DateServiceMock());
 
-        var result = service.ParseTask("Test !*");
+        var result = service.ParseTasks("Test !*").Single();
 
         Assert.Equal("Test !*", result.Title);
         Assert.Equal(TaskTypeDto.Simple, result.Type);
@@ -362,11 +363,11 @@ public class TaskParserServiceTest : BaseTest
     }
 
     [Fact]
-    public void ParseTask_IgnoreDateTaskWithTime()
+    public void ParseTaskTemplate_TaskWithTime_SkipsDate()
     {
         var service = new TaskParserService(DateServiceMock());
 
-        var result = service.ParseTask("1010 Test!", ignoreDate: true);
+        var result = service.ParseTaskTemplate("1010 Test!");
 
         Assert.Equal("Test!", result.Title);
         Assert.Equal(TaskTypeDto.Simple, result.Type);
@@ -376,11 +377,11 @@ public class TaskParserServiceTest : BaseTest
 
     // #24
     [Fact]
-    public void ParseTask_ReturnWeeklyTask()
+    public void ParseTasks_ReturnWeeklyTask()
     {
         var service = new TaskParserService(DateServiceMock());
 
-        var result = service.ParseTask("Test %");
+        var result = service.ParseTasks("Test %").Single();
 
         Assert.Equal("Test", result.Title);
         Assert.Equal(TaskTypeDto.Weekly, result.Type);
@@ -391,11 +392,11 @@ public class TaskParserServiceTest : BaseTest
 
     // #25
     [Fact]
-    public void ParseTask_WeeklyAndProbable()
+    public void ParseTasks_WeeklyAndProbable()
     {
         var service = new TaskParserService(DateServiceMock());
 
-        var result = service.ParseTask("Test %?");
+        var result = service.ParseTasks("Test %?").Single();
 
         Assert.Equal("Test", result.Title);
         Assert.Equal(TaskTypeDto.Weekly, result.Type);
@@ -406,11 +407,11 @@ public class TaskParserServiceTest : BaseTest
 
     // #25.1
     [Fact]
-    public void ParseTask_ProbableAndWeekly()
+    public void ParseTasks_ProbableAndWeekly()
     {
         var service = new TaskParserService(DateServiceMock());
 
-        var result = service.ParseTask("Test ?%");
+        var result = service.ParseTasks("Test ?%").Single();
 
         Assert.Equal("Test", result.Title);
         Assert.Equal(TaskTypeDto.Weekly, result.Type);
@@ -421,11 +422,11 @@ public class TaskParserServiceTest : BaseTest
 
     // #26
     [Fact]
-    public void ParseTask_WeeklyDuplicateCancels()
+    public void ParseTasks_WeeklyDuplicateCancels()
     {
         var service = new TaskParserService(DateServiceMock());
 
-        var result = service.ParseTask("Test %%");
+        var result = service.ParseTasks("Test %%").Single();
 
         Assert.Equal("Test %%", result.Title);
         Assert.Equal(TaskTypeDto.Simple, result.Type);
@@ -436,11 +437,11 @@ public class TaskParserServiceTest : BaseTest
 
     // #27
     [Fact]
-    public void ParseTask_WeeklyAndRoutineConflict()
+    public void ParseTasks_WeeklyAndRoutineConflict()
     {
         var service = new TaskParserService(DateServiceMock());
 
-        var result = service.ParseTask("Test %*");
+        var result = service.ParseTasks("Test %*").Single();
 
         Assert.Equal("Test %*", result.Title);
         Assert.Equal(TaskTypeDto.Simple, result.Type);
@@ -451,17 +452,155 @@ public class TaskParserServiceTest : BaseTest
 
     // #28
     [Fact]
-    public void ParseTask_ProbableWeeklyProbableConflict()
+    public void ParseTasks_ProbableWeeklyProbableConflict()
     {
         var service = new TaskParserService(DateServiceMock());
 
-        var result = service.ParseTask("Test ?%?");
+        var result = service.ParseTasks("Test ?%?").Single();
 
         Assert.Equal("Test ?%?", result.Title);
         Assert.Equal(TaskTypeDto.Simple, result.Type);
         Assert.False(result.IsProbable);
         Assert.Null(result.Date);
         Assert.Null(result.Time);
+    }
+
+    // [Date range] tests #29-#39 are synced 1:1 with FE TaskConvertService range tests.
+    // On BE, ParseTask combines parse + validation + expansion, so invalid ranges throw,
+    // whereas FE exposes parse / expand / validate as separate methods.
+
+    // #29
+    [Fact]
+    public void ParseTasks_DateRangeWithoutYear_CreatesTaskPerInclusiveDay()
+    {
+        var service = new TaskParserService(DateServiceMock());
+
+        var result = service.ParseTasks("0909-0913 venice");
+
+        Assert.Equal(5, result.Count);
+        Assert.Equal(new DateTime(2019, 9, 9), result[0].Date);
+        Assert.Equal(new DateTime(2019, 9, 13), result[4].Date);
+        Assert.All(result, x => Assert.Equal("venice", x.Title));
+    }
+
+    // #30
+    [Fact]
+    public void ParseTasks_DateRangeWithTimeAndType_AppliesToEveryTask()
+    {
+        var service = new TaskParserService(DateServiceMock());
+
+        var result = service.ParseTasks("0909-0913 1012 venice !");
+
+        Assert.Equal(5, result.Count);
+        Assert.Equal(new DateTime(2019, 9, 9), result[0].Date);
+        Assert.Equal(new DateTime(2019, 9, 13), result[4].Date);
+        Assert.All(result, x =>
+        {
+            Assert.Equal("venice", x.Title);
+            Assert.Equal(TaskTypeDto.Additional, x.Type);
+            Assert.Equal(612, x.Time);
+        });
+    }
+
+    // #31
+    [Fact]
+    public void ParseTasks_DateRangeWithYearOnBothEndpoints_ParsesYears()
+    {
+        var service = new TaskParserService(DateServiceMock());
+
+        var result = service.ParseTasks("20270909-20270915 venice");
+
+        Assert.Equal(7, result.Count);
+        Assert.Equal(new DateTime(2027, 9, 9), result[0].Date);
+        Assert.Equal(new DateTime(2027, 9, 15), result[6].Date);
+    }
+
+    // #32
+    [Fact]
+    public void ParseTasks_DateRangeWithMixedYearEndpoints_ParsesEachEndpointIndependently()
+    {
+        var service = new TaskParserService(DateServiceMock());
+
+        var result = service.ParseTasks("0909-20190915 venice");
+
+        Assert.Equal(7, result.Count);
+        Assert.Equal(new DateTime(2019, 9, 9), result[0].Date);
+        Assert.Equal(new DateTime(2019, 9, 15), result[6].Date);
+    }
+
+    // #33
+    [Fact]
+    public void ParseTasks_DateRangeWithoutSpace_NotTreatedAsRange()
+    {
+        var service = new TaskParserService(DateServiceMock());
+
+        var result = service.ParseTasks("0909-0913venice");
+
+        Assert.Single(result);
+        Assert.Equal("0909-0913venice", result[0].Title);
+        Assert.Null(result[0].Date);
+    }
+
+    // #34
+    [Fact]
+    public void ParseTasks_SingleDayRange_Throws()
+    {
+        var service = new TaskParserService(DateServiceMock());
+
+        Assert.Throws<ServiceException>(() => service.ParseTasks("0909-0909 venice"));
+    }
+
+    // #35
+    [Fact]
+    public void ParseTasks_DateRangeAtLimit_CreatesTasks()
+    {
+        var service = new TaskParserService(DateServiceMock());
+
+        var result = service.ParseTasks("0901-1001 venice");
+
+        Assert.Equal(31, result.Count);
+        Assert.Equal(new DateTime(2019, 9, 1), result[0].Date);
+        Assert.Equal(new DateTime(2019, 10, 1), result[30].Date);
+    }
+
+    // #36
+    [Fact]
+    public void ParseTasks_DateRangeExceedingLimit_Throws()
+    {
+        var service = new TaskParserService(DateServiceMock());
+
+        Assert.Throws<ServiceException>(() => service.ParseTasks("0901-1002 venice"));
+    }
+
+    // #37
+    [Fact]
+    public void ParseTasks_MultiYearDateRange_Throws()
+    {
+        var service = new TaskParserService(DateServiceMock());
+
+        Assert.Throws<ServiceException>(() => service.ParseTasks("20270909-20280913 venice"));
+    }
+
+    // #38
+    [Fact]
+    public void ParseTasks_ReversedDateRange_Throws()
+    {
+        var service = new TaskParserService(DateServiceMock());
+
+        Assert.Throws<ServiceException>(() => service.ParseTasks("0913-0909 venice"));
+    }
+
+    // #39
+    [Fact]
+    public void ParseTasks_MinimumValidRange_CreatesTwoTasks()
+    {
+        var service = new TaskParserService(DateServiceMock());
+
+        var result = service.ParseTasks("0910-0911 venice");
+
+        Assert.Equal(2, result.Count);
+        Assert.Equal(new DateTime(2019, 9, 10), result[0].Date);
+        Assert.Equal(new DateTime(2019, 9, 11), result[1].Date);
     }
 
     private static IDateService DateServiceMock(int year = 2019, int month = 1, int date = 1)

--- a/code/backend/DD.Tests.Unit/TelegramClient/Services/BotCommandParserServiceTest.cs
+++ b/code/backend/DD.Tests.Unit/TelegramClient/Services/BotCommandParserServiceTest.cs
@@ -1,5 +1,3 @@
-using DD.Shared.Details.Abstractions;
-using DD.Shared.Details.Abstractions.Dto;
 using DD.TelegramClient.Domain.Models.Commands;
 using DD.TelegramClient.Domain.Services;
 using Moq;
@@ -12,18 +10,15 @@ public class BotCommandParserServiceTest
     [Fact]
     public async Task ParseCommand_CreateTask()
     {
-        var task = new TaskDto();
         var telegramMock = new Mock<ITelegramService>();
-        var taskParserMock = new Mock<ITaskServiceApp>();
-        taskParserMock.Setup(x => x.ParseTask("Some task")).Returns(Task.FromResult(task));
         var dateServiceMock = new Mock<IDateService>();
-        var service = new BotCommandParserService(telegramMock.Object, dateServiceMock.Object, taskParserMock.Object);
+        var service = new BotCommandParserService(telegramMock.Object, dateServiceMock.Object);
 
         var result = await service.ParseCommand("Some task", 100500);
 
         Assert.NotNull(result);
         Assert.IsType<CreateTaskCommand>(result);
-        Assert.Same(task, ((CreateTaskCommand)result).Task);
+        Assert.Equal("Some task", ((CreateTaskCommand)result).Text);
     }
 
     [Fact]
@@ -33,8 +28,7 @@ public class BotCommandParserServiceTest
         dateServiceMock.SetupGet(x => x.Now).Returns(new DateTime(2010, 10, 10));
         var telegramMock = new Mock<ITelegramService>();
         telegramMock.Setup(x => x.GetUserTimeAdjustment(100500)).Returns(Task.FromResult(100));
-        var taskServiceAppMock = new Mock<ITaskServiceApp>();
-        var service = new BotCommandParserService(telegramMock.Object, dateServiceMock.Object, taskServiceAppMock.Object);
+        var service = new BotCommandParserService(telegramMock.Object, dateServiceMock.Object);
 
         var result = await service.ParseCommand("/todo", 100500);
 
@@ -49,8 +43,7 @@ public class BotCommandParserServiceTest
     {
         var dateServiceMock = new Mock<IDateService>();
         var telegramServiceMock = new Mock<ITelegramService>();
-        var taskServiceAppMock = new Mock<ITaskServiceApp>();
-        var service = new BotCommandParserService(telegramServiceMock.Object, dateServiceMock.Object, taskServiceAppMock.Object);
+        var service = new BotCommandParserService(telegramServiceMock.Object, dateServiceMock.Object);
 
         var result = await service.ParseCommand("/start SomeChatKey", 0);
 

--- a/code/backend/DD.Tests.Unit/TelegramClient/Services/BotProcessMessageServiceTest.cs
+++ b/code/backend/DD.Tests.Unit/TelegramClient/Services/BotProcessMessageServiceTest.cs
@@ -1,4 +1,3 @@
-using DD.Shared.Details.Abstractions.Dto;
 using DD.TelegramClient.Domain.Dto;
 using DD.TelegramClient.Domain.Models.Commands;
 using DD.TelegramClient.Domain.Services;
@@ -68,8 +67,7 @@ public class BotProcessMessageServiceTest
     [Fact]
     public async Task BotProcessMessageServiceTest_RunCreateTaskCommand()
     {
-        var task = new TaskDto();
-        var command = new CreateTaskCommand(task);
+        var command = new CreateTaskCommand("Some task");
         var commandParserMock = CreateCommandParserMock(command);
         var commandMock = new Mock<ICreateTaskCommandProcessor>();
         var botSendMessageServiceMock = new Mock<IBotSendMessageService>();

--- a/code/backend/DD.Tests.Unit/TelegramClient/Services/CommandProcessor/CreateTaskCommandProcessorTest.cs
+++ b/code/backend/DD.Tests.Unit/TelegramClient/Services/CommandProcessor/CreateTaskCommandProcessorTest.cs
@@ -1,3 +1,4 @@
+using DD.ServiceTask.Domain.Exceptions;
 using DD.Shared.Details.Abstractions;
 using DD.Shared.Details.Abstractions.Dto;
 using DD.TelegramClient.Domain.Models.Commands;
@@ -28,7 +29,7 @@ public class CreateTaskCommandProcessorTest
             taskServiceMock.Object,
             loggerMock.Object);
 
-        await service.ProcessAsync(new CreateTaskCommand(task)
+        await service.ProcessAsync(new CreateTaskCommand("Some task")
         {
             UserChatId = 100,
         });
@@ -38,6 +39,36 @@ public class CreateTaskCommandProcessorTest
             It.Is<ICollection<TaskDto>>(y => y.Any(e => e.Title == "Task")),
             "userid",
             It.IsAny<string?>()));
+    }
+
+    [Fact]
+    public async Task ProcessAsync_WhenParseThrows_SendsFailedAndDoesNotSave()
+    {
+        var telegramMock = new Mock<ITelegramService>();
+        telegramMock.Setup(x => x.GetUserId(100)).Returns(Task.FromResult("userid"));
+
+        var taskServiceMock = new Mock<ITaskServiceApp>();
+        taskServiceMock.Setup(x => x.ParseTasks(It.IsAny<string>()))
+            .Throws(ServiceException.InvalidDateRange(31));
+
+        var sendMessageMock = new Mock<IBotSendMessageService>();
+        var loggerMock = new Mock<ILogger<BaseCommandProcessor<BotCommand>>>();
+
+        var service = new CreateTaskCommandProcessor(
+            sendMessageMock.Object,
+            telegramMock.Object,
+            taskServiceMock.Object,
+            loggerMock.Object);
+
+        await service.ProcessAsync(new CreateTaskCommand("0901-1002 venice")
+        {
+            UserChatId = 100,
+        });
+
+        sendMessageMock.Verify(x => x.SendFailedAsync(100));
+        taskServiceMock.Verify(
+            x => x.SaveTasksAsync(It.IsAny<ICollection<TaskDto>>(), It.IsAny<string>(), It.IsAny<string?>()),
+            Times.Never);
     }
 
     private static (
@@ -52,6 +83,8 @@ public class CreateTaskCommandProcessorTest
             .Returns(Task.FromResult("userid"));
 
         var taskServiceMock = new Mock<ITaskServiceApp>();
+        taskServiceMock.Setup(x => x.ParseTasks("Some task"))
+            .Returns(Task.FromResult<IReadOnlyList<TaskDto>>([task]));
         taskServiceMock.Setup(x => x.SaveTasksAsync(It.Is<ICollection<TaskDto>>(v => v.Contains(task)), "userid", It.IsAny<string?>()))
             .Returns(Task.FromResult((IEnumerable<TaskDto>)tasks));
 

--- a/code/frontend/src/edit-task/EditTaskModal.tsx
+++ b/code/frontend/src/edit-task/EditTaskModal.tsx
@@ -1,7 +1,9 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { TaskModel } from '../tasks/models/TaskModel'
 import { taskConvertService } from './services/TaskConvertService'
+import { MAX_RANGE_DAYS, MIN_RANGE_DAYS, taskRangeService } from './services/TaskRangeService'
 import { TaskEditModalContext } from './models/TaskEditModalContext'
+import { TaskEditModel, TaskSingleEditModel } from './models/TaskEditModel'
 import { EditTaskHelper } from './components/EditTaskHelper'
 import { ModalContainer } from '../common/components/ModalContainer'
 import { useTaskConflictDetection } from './hooks/useTaskConflictDetection'
@@ -9,6 +11,35 @@ import { useTaskConflictDetection } from './hooks/useTaskConflictDetection'
 interface Props {
     context: TaskEditModalContext
     onSave: (task: TaskModel[]) => void
+}
+
+// Collapses a range-capable model to a single-date model. The one place dateTo is dropped.
+function toSingleModel(model: TaskEditModel): TaskSingleEditModel {
+    return {
+        date: model.date,
+        type: model.type,
+        title: model.title,
+        isProbable: model.isProbable,
+        time: model.time,
+    }
+}
+
+function getError(model: TaskEditModel | TaskSingleEditModel): string | null {
+    const dayCount = 'dateTo' in model ? taskRangeService.getRangeDayCount(model) : null
+
+    if (dayCount === null) {
+        return null
+    }
+
+    if (dayCount < MIN_RANGE_DAYS) {
+        return 'Invalid date range: the end date must be after the start date'
+    }
+
+    if (dayCount > MAX_RANGE_DAYS) {
+        return `Date range is too large: maximum ${MAX_RANGE_DAYS} days`
+    }
+
+    return null
 }
 
 function EditTaskModal({ context, onSave }: Props) {
@@ -31,17 +62,28 @@ function EditTaskModal({ context, onSave }: Props) {
 
     const editModel = useMemo(() => taskConvertService.convertStringToModel(task), [task])
 
+    // EDIT collapses to a single-date model so a typed range is ignored (variant A). Create keeps
+    // the range-capable model; the helper itself renders a range only when dateTo is set.
+    const helperModel = useMemo(
+        () => (content.type === 'EDIT' ? toSingleModel(editModel) : editModel),
+        [editModel, content],
+    )
+
+    const error = useMemo(() => getError(helperModel), [helperModel])
+
     const handleSave = useCallback(() => {
-        setTask('')
-        if (editModel !== null) {
-            onSave([
-                content.type === 'EDIT'
-                    ? taskConvertService.mergeTaskWithModel(editModel, content.task)
-                    : taskConvertService.createTaskFromModel(editModel),
-            ])
-            close()
+        if (error !== null) {
+            return
         }
-    }, [editModel, onSave, content, close])
+
+        setTask('')
+        onSave(
+            content.type === 'EDIT'
+                ? [taskConvertService.mergeTaskWithModel(editModel, content.task)]
+                : taskConvertService.createTasksFromModel(editModel),
+        )
+        close()
+    }, [editModel, onSave, content, close, error])
 
     const handleTaskChange = (e: React.ChangeEvent<HTMLInputElement>) => {
         setTask(e.target.value)
@@ -60,8 +102,8 @@ function EditTaskModal({ context, onSave }: Props) {
             context={context}
             onSave={handleSave}
             autoFocusInputRef={inputRef}
-            isSaveEnabled={task.length > 0}
-            hasWarning={conflictTask !== null}
+            isSaveEnabled={task.length > 0 && error === null}
+            hasWarning={conflictTask !== null || error !== null}
         >
             <div className="form-floating mb-3">
                 <input
@@ -76,7 +118,8 @@ function EditTaskModal({ context, onSave }: Props) {
                 />
                 <label htmlFor="taskInput">{label}</label>
             </div>
-            {editModel && <EditTaskHelper task={editModel} />}
+            <EditTaskHelper task={helperModel} />
+            {error && <p className="text-danger mb-0 mt-2">{error}</p>}
         </ModalContainer>
     )
 }

--- a/code/frontend/src/edit-task/components/EditTaskHelper.tsx
+++ b/code/frontend/src/edit-task/components/EditTaskHelper.tsx
@@ -1,14 +1,23 @@
 import { dateService } from '../../common/services/DateService'
 import { TaskTypeEnum } from '../../tasks/models/TaskTypeEnum'
-import { TaskEditModel } from '../models/TaskEditModel'
+import { TaskEditModel, TaskSingleEditModel } from '../models/TaskEditModel'
 import { taskConvertService } from '../services/TaskConvertService'
+import { taskRangeService } from '../services/TaskRangeService'
 
 interface Props {
-    task: TaskEditModel
+    task: TaskEditModel | TaskSingleEditModel
 }
 
 function EditTaskHelper({ task }: Props) {
-    const date = task.date ? taskConvertService.toDateLabel(task.date) : ''
+    const range =
+        'dateTo' in task && task.dateTo !== null
+            ? { endDate: task.dateTo, taskCount: taskRangeService.getRangeDayCount(task) }
+            : null
+    const date = task.date
+        ? range
+            ? `${taskConvertService.toDateLabel(task.date)} – ${taskConvertService.toDateLabel(range.endDate)}`
+            : taskConvertService.toDateLabel(task.date)
+        : ''
     const time = task.time ? dateService.toTimeLabel(task.time) : ''
     const type = getType(task.type)
     const isProbable = task.isProbable ? 'Probable' : ''
@@ -23,6 +32,12 @@ function EditTaskHelper({ task }: Props) {
             {date && (
                 <>
                     Date: {date}
+                    <br />
+                </>
+            )}
+            {range && range.taskCount !== null && range.taskCount > 1 && (
+                <>
+                    Tasks: {range.taskCount}
                     <br />
                 </>
             )}

--- a/code/frontend/src/edit-task/models/TaskEditModel.ts
+++ b/code/frontend/src/edit-task/models/TaskEditModel.ts
@@ -1,9 +1,13 @@
 import { TaskTypeEnum } from '../../tasks/models/TaskTypeEnum'
 
-export interface TaskEditModel {
+export interface TaskSingleEditModel {
     date: Date | null
     type: TaskTypeEnum
     title: string
     isProbable: boolean
     time: number | null
+}
+
+export interface TaskEditModel extends TaskSingleEditModel {
+    dateTo: Date | null
 }

--- a/code/frontend/src/edit-task/services/TaskConvertService.ts
+++ b/code/frontend/src/edit-task/services/TaskConvertService.ts
@@ -2,7 +2,7 @@ import { dateService, DateService, Time } from '../../common/services/DateServic
 import { uuidv4 } from '../../common/utils/uuidv4'
 import { TaskModel } from '../../tasks/models/TaskModel'
 import { TaskTypeEnum } from '../../tasks/models/TaskTypeEnum'
-import { TaskEditModel } from '../models/TaskEditModel'
+import { TaskEditModel, TaskSingleEditModel } from '../models/TaskEditModel'
 
 export class TaskConvertService {
     constructor(private dateService: DateService) {}
@@ -17,7 +17,7 @@ export class TaskConvertService {
         return this.convertModelToString(model)
     }
 
-    createTaskFromModel(result: TaskEditModel): TaskModel {
+    private createTaskFromModel(result: TaskSingleEditModel): TaskModel {
         return {
             uid: uuidv4(),
             title: result.title,
@@ -32,7 +32,23 @@ export class TaskConvertService {
         }
     }
 
-    mergeTaskWithModel(result: TaskEditModel, task: TaskModel): TaskModel {
+    createTasksFromModel(result: TaskEditModel): TaskModel[] {
+        if (result.date === null || result.dateTo === null) {
+            return [this.createTaskFromModel(result)]
+        }
+
+        const tasks: TaskModel[] = []
+        const date = new Date(result.date)
+
+        while (date.getTime() <= result.dateTo.getTime()) {
+            tasks.push(this.createTaskFromModel({ ...result, date: new Date(date) }))
+            date.setDate(date.getDate() + 1)
+        }
+
+        return tasks
+    }
+
+    mergeTaskWithModel(result: TaskSingleEditModel, task: TaskModel): TaskModel {
         return {
             ...task,
             title: result.title,
@@ -46,15 +62,15 @@ export class TaskConvertService {
     convertStringToModel(text: string): TaskEditModel {
         const result = new StringConvertingResult(this.dateService.today())
 
-        if (/^\d{8}\s/.test(text)) {
+        if (/^(\d{8}|\d{4})-(\d{8}|\d{4})\s/.test(text)) {
             result.setHasDate()
-            text = result.extractYear(text)
-            text = result.extractMonth(text)
-            text = result.extractDay(text)
+            text = result.extractDateRange(text)
+        } else if (/^\d{8}\s/.test(text)) {
+            result.setHasDate()
+            text = result.extractDate(text, 8)
         } else if (/^\d{4}\s/.test(text)) {
             result.setHasDate()
-            text = result.extractMonth(text)
-            text = result.extractDay(text)
+            text = result.extractDate(text, 4)
         } else if (/^!+\s/.test(text)) {
             result.setHasDate()
             text = result.extractTodayShift(text)
@@ -80,7 +96,7 @@ export class TaskConvertService {
         return result.getModel(text)
     }
 
-    convertModelToString(model: TaskEditModel): string {
+    private convertModelToString(model: TaskSingleEditModel): string {
         let s = ''
 
         if (model.date !== null) {
@@ -139,7 +155,7 @@ export class TaskConvertService {
         return s
     }
 
-    private convertTaskToModel(task: TaskModel | null): TaskEditModel | null {
+    private convertTaskToModel(task: TaskModel | null): TaskSingleEditModel | null {
         if (task === null) {
             return null
         }
@@ -175,23 +191,63 @@ class StringConvertingResult {
     private type: TaskTypeEnum = TaskTypeEnum.Simple
     private isProbable = false
 
+    private hasRange = false
+    private yearTo = 0
+    private monthTo = 0
+    private dayTo = 1
+
     constructor(private now: Date) {
         this.year = this.now.getFullYear()
     }
 
-    extractYear(text: string): string {
-        this.year = Number(text.substr(0, 4))
-        return text.slice(4)
+    // Extracts a leading date token of the given length (4 = MMDD, 8 = YYYYMMDD) and
+    // returns the remaining text. Shares the token parser with the date-range endpoints.
+    extractDate(text: string, length: number): string {
+        const parsed = this.parseStringDate(text.substr(0, length))
+        this.year = parsed.year
+        this.month = parsed.month
+        this.day = parsed.day
+        return text.slice(length)
     }
 
-    extractMonth(text: string): string {
-        this.month = Number(text.substr(0, 2))
-        return text.slice(2)
+    // Range form "<start>-<end>": each endpoint is parsed independently as a standalone
+    // date (8 digits = explicit year, 4 digits = current year) via parseStringDate.
+    extractDateRange(text: string): string {
+        const match = /^(\d{8}|\d{4})-(\d{8}|\d{4})\s/.exec(text)
+
+        if (match === null) {
+            return text
+        }
+
+        const start = this.parseStringDate(match[1])
+        const end = this.parseStringDate(match[2])
+
+        this.year = start.year
+        this.month = start.month
+        this.day = start.day
+        this.yearTo = end.year
+        this.monthTo = end.month
+        this.dayTo = end.day
+        this.hasRange = true
+
+        return text.slice(match[0].length)
     }
 
-    extractDay(text: string): string {
-        this.day = Number(text.substr(0, 2))
-        return text.slice(2)
+    // Parses a numeric date token in either MMDD (current year) or YYYYMMDD form.
+    private parseStringDate(token: string): { year: number; month: number; day: number } {
+        if (token.length === 8) {
+            return {
+                year: Number(token.substr(0, 4)),
+                month: Number(token.substr(4, 2)),
+                day: Number(token.substr(6, 2)),
+            }
+        }
+
+        return {
+            year: this.now.getFullYear(),
+            month: Number(token.substr(0, 2)),
+            day: Number(token.substr(2, 2)),
+        }
     }
 
     extractTodayShift(text: string): string {
@@ -272,6 +328,7 @@ class StringConvertingResult {
     getModel(text: string): TaskEditModel {
         return {
             date: this.hasDate ? new Date(this.year, this.month - 1, this.day) : null,
+            dateTo: this.hasRange ? new Date(this.yearTo, this.monthTo - 1, this.dayTo) : null,
             type: this.type,
             title: text,
             isProbable: this.isProbable,

--- a/code/frontend/src/edit-task/services/TaskRangeService.ts
+++ b/code/frontend/src/edit-task/services/TaskRangeService.ts
@@ -1,0 +1,18 @@
+import { TaskEditModel } from '../models/TaskEditModel'
+
+export const MIN_RANGE_DAYS = 2
+export const MAX_RANGE_DAYS = 31
+
+const MS_PER_DAY = 24 * 60 * 60 * 1000
+
+export class TaskRangeService {
+    getRangeDayCount(model: TaskEditModel): number | null {
+        if (model.date === null || model.dateTo === null) {
+            return null
+        }
+
+        return Math.round((model.dateTo.getTime() - model.date.getTime()) / MS_PER_DAY) + 1
+    }
+}
+
+export const taskRangeService = new TaskRangeService()

--- a/code/frontend/tests/services/TaskConvertService.test.ts
+++ b/code/frontend/tests/services/TaskConvertService.test.ts
@@ -3,9 +3,26 @@ import { expect, test } from 'vitest'
 import { TaskConvertService } from '../../src/edit-task/services/TaskConvertService'
 import { DateService } from '../../src/common/services/DateService'
 import { TaskTypeEnum } from '../../src/tasks/models/TaskTypeEnum'
+import { TaskModel } from '../../src/tasks/models/TaskModel'
 
 function dt(year: number, month: number, date: number): number {
     return new Date(year, month, date).valueOf()
+}
+
+function task(partial: Partial<TaskModel>): TaskModel {
+    return {
+        uid: 'uid',
+        title: '',
+        date: null,
+        order: 0,
+        completed: false,
+        deleted: false,
+        type: TaskTypeEnum.Simple,
+        isProbable: false,
+        version: 0,
+        time: null,
+        ...partial,
+    }
 }
 
 function createService(date?: Date): TaskConvertService {
@@ -373,123 +390,170 @@ test('[convertStringToModel] probable weekly probable conflict', () => {
     expect(result.time).toBeNull()
 })
 
-test('[convertModelToString] no date', () => {
+// [Date range] parsing + expansion tests. Range day-count and validity live in
+// TaskRangeService.test.ts. Together they mirror BE TaskParserService.ParseTasks range
+// tests (#29-#39), which combine parse + validate + expand in one method.
+
+// #29
+test('[convertStringToModel] date range without year', () => {
     const service = createService()
-    const result = service.convertModelToString({
-        title: 'Test!',
-        type: TaskTypeEnum.Simple,
-        date: null,
-        time: null,
-        isProbable: false,
-    })
+    const result = service.convertStringToModel('0909-0913 venice')
+
+    expect(result.title).toBe('venice')
+    expect(result.date?.valueOf()).toBe(dt(2019, 8, 9))
+    expect(result.dateTo?.valueOf()).toBe(dt(2019, 8, 13))
+    expect(result.time).toBeNull()
+})
+
+// #30
+test('[createTasksFromModel] date range with time and type applies to every task', () => {
+    const service = createService()
+    const tasks = service.createTasksFromModel(service.convertStringToModel('0909-0913 1012 venice !'))
+
+    expect(tasks.length).toBe(5)
+    expect(tasks[0].date).toBe(dt(2019, 8, 9))
+    expect(tasks[4].date).toBe(dt(2019, 8, 13))
+    expect(tasks.every(t => t.time === 612)).toBe(true)
+    expect(tasks.every(t => t.type === TaskTypeEnum.Additional)).toBe(true)
+    expect(tasks.every(t => t.title === 'venice')).toBe(true)
+})
+
+// #31
+test('[convertStringToModel] date range with year on both endpoints', () => {
+    const service = createService()
+    const result = service.convertStringToModel('20270909-20270915 venice')
+
+    expect(result.title).toBe('venice')
+    expect(result.date?.valueOf()).toBe(dt(2027, 8, 9))
+    expect(result.dateTo?.valueOf()).toBe(dt(2027, 8, 15))
+})
+
+// #32
+test('[convertStringToModel] date range with mixed year endpoints', () => {
+    const service = createService()
+    const result = service.convertStringToModel('0909-20190915 venice')
+
+    expect(result.title).toBe('venice')
+    expect(result.date?.valueOf()).toBe(dt(2019, 8, 9))
+    expect(result.dateTo?.valueOf()).toBe(dt(2019, 8, 15))
+})
+
+// #33
+test('[convertStringToModel] date range not parsed without space', () => {
+    const service = createService()
+    const result = service.convertStringToModel('0909-0913venice')
+
+    expect(result.title).toBe('0909-0913venice')
+    expect(result.date).toBeNull()
+    expect(result.dateTo).toBeNull()
+})
+
+// #35 (expansion side; day-count/validity asserted in TaskRangeService.test.ts)
+test('[createTasksFromModel] range at the limit creates one task per inclusive day', () => {
+    const service = createService()
+    const tasks = service.createTasksFromModel(service.convertStringToModel('0901-1001 venice'))
+
+    expect(tasks.length).toBe(31)
+    expect(tasks[0].date).toBe(dt(2019, 8, 1))
+    expect(tasks[30].date).toBe(dt(2019, 9, 1))
+})
+
+// #39 (expansion side; day-count/validity asserted in TaskRangeService.test.ts)
+test('[createTasksFromModel] minimum valid range creates two tasks', () => {
+    const service = createService()
+    const tasks = service.createTasksFromModel(service.convertStringToModel('0910-0911 venice'))
+
+    expect(tasks.length).toBe(2)
+    expect(tasks[0].date).toBe(dt(2019, 8, 10))
+    expect(tasks[1].date).toBe(dt(2019, 8, 11))
+})
+
+// [FE-only] convertStringToModel parses time and type alongside a range (model-level check)
+test('[convertStringToModel] date range with time and type', () => {
+    const service = createService()
+    const result = service.convertStringToModel('0909-0913 1012 venice !')
+
+    expect(result.title).toBe('venice')
+    expect(result.type).toBe(TaskTypeEnum.Additional)
+    expect(result.date?.valueOf()).toBe(dt(2019, 8, 9))
+    expect(result.dateTo?.valueOf()).toBe(dt(2019, 8, 13))
+    expect(result.time).toBe(612)
+})
+
+// [FE-only] createTasksFromModel without a range yields a single task (dateTo === null branch)
+test('[createTasksFromModel] no range creates one task', () => {
+    const service = createService()
+    const tasks = service.createTasksFromModel(service.convertStringToModel('0909 venice'))
+
+    expect(tasks.length).toBe(1)
+    expect(tasks[0].date).toBe(dt(2019, 8, 9))
+})
+
+test('[convertTaskToString] no date', () => {
+    const service = createService()
+    const result = service.convertTaskToString(task({ title: 'Test!' }))
     expect(result).toBe('Test!')
 })
 
-test('[convertModelToString] date & no time', () => {
+test('[convertTaskToString] date & no time', () => {
     const service = createService()
-    const result = service.convertModelToString({
-        title: 'Test!',
-        type: TaskTypeEnum.Simple,
-        date: new Date(2019, 11, 11),
-        time: null,
-        isProbable: false,
-    })
+    const result = service.convertTaskToString(task({ title: 'Test!', date: dt(2019, 11, 11) }))
     expect(result).toBe('1211 Test!')
 })
 
-test('[convertModelToString] date & time', () => {
+test('[convertTaskToString] date & time', () => {
     const service = createService()
-    const result = service.convertModelToString({
-        title: 'Test!',
-        type: TaskTypeEnum.Simple,
-        date: new Date(2019, 11, 11),
-        time: 1439,
-        isProbable: false,
-    })
+    const result = service.convertTaskToString(task({ title: 'Test!', date: dt(2019, 11, 11), time: 1439 }))
     expect(result).toBe('1211 2359 Test!')
 })
 
-test('[convertModelToString] date & time less ten', () => {
+test('[convertTaskToString] date & time less ten', () => {
     const service = createService()
-    const result = service.convertModelToString({
-        title: 'Test!',
-        type: TaskTypeEnum.Simple,
-        date: new Date(2019, 0, 1),
-        time: 61,
-        isProbable: false,
-    })
+    const result = service.convertTaskToString(task({ title: 'Test!', date: dt(2019, 0, 1), time: 61 }))
     expect(result).toBe('0101 0101 Test!')
 })
 
-test('[convertModelToString] is probable', () => {
+test('[convertTaskToString] is probable', () => {
     const service = createService()
-    const result = service.convertModelToString({
-        title: 'Test!',
-        type: TaskTypeEnum.Simple,
-        date: null,
-        time: null,
-        isProbable: true,
-    })
+    const result = service.convertTaskToString(task({ title: 'Test!', isProbable: true }))
     expect(result).toBe('Test! ?')
 })
 
-test('[convertModelToString] additional', () => {
+test('[convertTaskToString] additional', () => {
     const service = createService()
-    const result = service.convertModelToString({
-        title: 'Test!',
-        type: TaskTypeEnum.Additional,
-        date: new Date(2019, 0, 1),
-        time: null,
-        isProbable: false,
-    })
+    const result = service.convertTaskToString(
+        task({ title: 'Test!', type: TaskTypeEnum.Additional, date: dt(2019, 0, 1) }),
+    )
     expect(result).toBe('0101 Test! !')
 })
 
-test('[convertModelToString] additional and probable', () => {
+test('[convertTaskToString] additional and probable', () => {
     const service = createService()
-    const result = service.convertModelToString({
-        title: 'Test!',
-        type: TaskTypeEnum.Additional,
-        date: new Date(2019, 0, 1),
-        time: null,
-        isProbable: true,
-    })
+    const result = service.convertTaskToString(
+        task({ title: 'Test!', type: TaskTypeEnum.Additional, date: dt(2019, 0, 1), isProbable: true }),
+    )
     expect(result).toBe('0101 Test! !?')
 })
 
-test('[convertModelToString] date with year', () => {
+test('[convertTaskToString] date with year', () => {
     const service = createService()
-    const result = service.convertModelToString({
-        title: 'Test!',
-        type: TaskTypeEnum.Simple,
-        date: new Date(2016, 11, 11),
-        time: null,
-        isProbable: false,
-    })
+    const result = service.convertTaskToString(task({ title: 'Test!', date: dt(2016, 11, 11) }))
     expect(result).toBe('20161211 Test!')
 })
 
-test('[convertModelToString] routine', () => {
+test('[convertTaskToString] routine', () => {
     const service = createService()
-    const result = service.convertModelToString({
-        title: 'Test!',
-        type: TaskTypeEnum.Routine,
-        date: new Date(2019, 0, 1),
-        time: null,
-        isProbable: false,
-    })
+    const result = service.convertTaskToString(
+        task({ title: 'Test!', type: TaskTypeEnum.Routine, date: dt(2019, 0, 1) }),
+    )
     expect(result).toBe('0101 Test! *')
 })
 
-test('[convertModelToString] routine and probable', () => {
+test('[convertTaskToString] routine and probable', () => {
     const service = createService()
-    const result = service.convertModelToString({
-        title: 'Test!',
-        type: TaskTypeEnum.Routine,
-        date: new Date(2019, 0, 1),
-        time: null,
-        isProbable: true,
-    })
+    const result = service.convertTaskToString(
+        task({ title: 'Test!', type: TaskTypeEnum.Routine, date: dt(2019, 0, 1), isProbable: true }),
+    )
     expect(result).toBe('0101 Test! *?')
 })
 

--- a/code/frontend/tests/services/TaskRangeService.test.ts
+++ b/code/frontend/tests/services/TaskRangeService.test.ts
@@ -1,0 +1,69 @@
+import { expect, test } from 'vitest'
+
+import { TaskConvertService } from '../../src/edit-task/services/TaskConvertService'
+import { MAX_RANGE_DAYS, MIN_RANGE_DAYS, TaskRangeService } from '../../src/edit-task/services/TaskRangeService'
+import { DateService } from '../../src/common/services/DateService'
+
+// Day-count + validity bounds for date ranges. The user-facing labels live in EditTaskModal.
+// These mirror the invalid/valid behaviour of BE TaskParserService.ParseTasks (#34-#39),
+// which throws on out-of-bounds ranges; on FE a count outside [MIN, MAX] is what marks a
+// range invalid (the parsing/expansion side is covered in TaskConvertService.test.ts).
+
+function parse(text: string) {
+    const dateServiceMock = { today: () => new Date(2019, 0, 1) } as unknown as DateService
+    return new TaskConvertService(dateServiceMock).convertStringToModel(text)
+}
+
+// #34
+test('[getRangeDayCount] single-day range is below the minimum', () => {
+    const service = new TaskRangeService()
+    const dayCount = service.getRangeDayCount(parse('0909-0909 venice'))
+
+    expect(dayCount).toBe(1)
+    expect(dayCount !== null && dayCount < MIN_RANGE_DAYS).toBe(true)
+})
+
+// #35
+test('[getRangeDayCount] range exactly at the limit', () => {
+    const service = new TaskRangeService()
+
+    expect(service.getRangeDayCount(parse('0901-1001 venice'))).toBe(MAX_RANGE_DAYS)
+})
+
+// #36
+test('[getRangeDayCount] range exceeding the limit', () => {
+    const service = new TaskRangeService()
+    const dayCount = service.getRangeDayCount(parse('0901-1002 venice'))
+
+    expect(dayCount).toBe(32)
+    expect(dayCount !== null && dayCount > MAX_RANGE_DAYS).toBe(true)
+})
+
+// #37
+test('[getRangeDayCount] multi-year range exceeds the limit', () => {
+    const service = new TaskRangeService()
+    const dayCount = service.getRangeDayCount(parse('20270909-20280913 venice'))
+
+    expect(dayCount !== null && dayCount > MAX_RANGE_DAYS).toBe(true)
+})
+
+// #38
+test('[getRangeDayCount] reversed range is below the minimum', () => {
+    const service = new TaskRangeService()
+    const dayCount = service.getRangeDayCount(parse('0913-0909 venice'))
+
+    expect(dayCount !== null && dayCount < MIN_RANGE_DAYS).toBe(true)
+})
+
+// #39
+test('[getRangeDayCount] minimum valid range', () => {
+    const service = new TaskRangeService()
+
+    expect(service.getRangeDayCount(parse('0910-0911 venice'))).toBe(MIN_RANGE_DAYS)
+})
+
+test('[getRangeDayCount] returns null without a range', () => {
+    const service = new TaskRangeService()
+
+    expect(service.getRangeDayCount(parse('0909 venice'))).toBeNull()
+})


### PR DESCRIPTION
- Extend date encoding to accept a range (MMDD-MMDD / YYYYMMDD-YYYYMMDD), creating one task per day across the inclusive range
- Add TaskRangeService (FE) with min 2 / max 31 day validation; show range, count, error; collapse to start date in EDIT
- Replace backend ParseTask(ignoreDate) with ParseTasks + ParseTaskTemplate; expand ranges, validate via ServiceException
- Keep symmetric parsing across web & Telegram; FE/BE parser tests synced 1:1

Backend 157 tests / frontend 122 tests green; browser smoke verified