### PR TITLE
[fix] PWA service worker not auto-updating frontend

### DIFF
--- a/code/frontend/vite.config.ts
+++ b/code/frontend/vite.config.ts
@@ -13,7 +13,7 @@ export default defineConfig({
         react(),
         VitePWA({
             registerType: 'autoUpdate',
-            injectRegister: 'inline',
+            injectRegister: 'auto',
             manifest: false,
             workbox: {
                 globPatterns: ['**/*.{js,css,html,ico,svg,png,json,woff,woff2}'],


### PR DESCRIPTION
Switch injectRegister from 'inline' to 'auto' so the generated sw.js includes skipWaiting and clientsClaim, letting a new worker activate without a manual unregister