### PR TITLE
[fix] Enter key not submitting login form with password managers

### DIFF
--- a/code/frontend/src/login/Login.tsx
+++ b/code/frontend/src/login/Login.tsx
@@ -33,8 +33,8 @@ function Login() {
     }, [dispatch])
 
     const handleSignin = useCallback(
-        async (username: string, password: string) => {
-            const actionResult = await dispatch(signin({ username, password }))
+        async (submittedUsername: string, submittedPassword: string) => {
+            const actionResult = await dispatch(signin({ username: submittedUsername, password: submittedPassword }))
             const loginResult = unwrapResult(actionResult)
 
             if (loginResult.result === SigninResultEnum.Success) {
@@ -45,8 +45,8 @@ function Login() {
     )
 
     const handleSignup = useCallback(
-        async (username: string, password: string) => {
-            const actionResult = await dispatch(signup({ username, password }))
+        async (submittedUsername: string, submittedPassword: string) => {
+            const actionResult = await dispatch(signup({ username: submittedUsername, password: submittedPassword }))
             const logInResult = unwrapResult(actionResult)
 
             if (logInResult.result === SignupResultEnum.Success) {

--- a/code/frontend/src/login/Login.tsx
+++ b/code/frontend/src/login/Login.tsx
@@ -32,23 +32,29 @@ function Login() {
         dispatch(resetLogInError())
     }, [dispatch])
 
-    const handleSignin = useCallback(async () => {
-        const actionResult = await dispatch(signin({ username, password }))
-        const loginResult = unwrapResult(actionResult)
+    const handleSignin = useCallback(
+        async (username: string, password: string) => {
+            const actionResult = await dispatch(signin({ username, password }))
+            const loginResult = unwrapResult(actionResult)
 
-        if (loginResult.result === SigninResultEnum.Success) {
-            signIn(loginResult.token)
-        }
-    }, [dispatch, signIn, password, username])
+            if (loginResult.result === SigninResultEnum.Success) {
+                signIn(loginResult.token)
+            }
+        },
+        [dispatch, signIn],
+    )
 
-    const handleSignup = useCallback(async () => {
-        const actionResult = await dispatch(signup({ username, password }))
-        const logInResult = unwrapResult(actionResult)
+    const handleSignup = useCallback(
+        async (username: string, password: string) => {
+            const actionResult = await dispatch(signup({ username, password }))
+            const logInResult = unwrapResult(actionResult)
 
-        if (logInResult.result === SignupResultEnum.Success) {
-            signIn(logInResult.token)
-        }
-    }, [dispatch, signIn, password, username])
+            if (logInResult.result === SignupResultEnum.Success) {
+                signIn(logInResult.token)
+            }
+        },
+        [dispatch, signIn],
+    )
 
     return (
         <Card className="container" style={{ maxWidth: '500px' }}>

--- a/code/frontend/src/login/components/Signin.tsx
+++ b/code/frontend/src/login/components/Signin.tsx
@@ -1,4 +1,4 @@
-import React, { useRef } from 'react'
+import { useRef } from 'react'
 import { isKeyEnter } from '../../common/utils/keys'
 
 interface Props {

--- a/code/frontend/src/login/components/Signin.tsx
+++ b/code/frontend/src/login/components/Signin.tsx
@@ -1,4 +1,5 @@
-import React from 'react'
+import React, { useRef } from 'react'
+import { isKeyEnter } from '../../common/utils/keys'
 
 interface Props {
     switchToSignup: () => void
@@ -6,7 +7,7 @@ interface Props {
     setUsername: (username: string) => void
     password: string
     setPassword: (password: string) => void
-    signin: () => void
+    signin: (username: string, password: string) => void
     isLogInPending: boolean
     logInError: string | null
 }
@@ -21,6 +22,9 @@ function Signin({
     isLogInPending,
     logInError,
 }: Props) {
+    const usernameRef = useRef<HTMLInputElement>(null)
+    const passwordRef = useRef<HTMLInputElement>(null)
+
     const handleSwitchToSignup = (e: React.MouseEvent) => {
         e.preventDefault()
         switchToSignup()
@@ -28,18 +32,33 @@ function Signin({
 
     const handleSubmit = (e: React.FormEvent) => {
         e.preventDefault()
-        signin()
+        const submittedUsername = usernameRef.current?.value ?? username
+        const submittedPassword = passwordRef.current?.value ?? password
+        setUsername(submittedUsername)
+        setPassword(submittedPassword)
+        if (!submittedUsername || !submittedPassword || isLogInPending) return
+        signin(submittedUsername, submittedPassword)
     }
 
-    const isSubmitEnabled = username && password && !isLogInPending
+    const isSubmitEnabled = !isLogInPending
+
+    const handleKeyDown = (e: React.KeyboardEvent<HTMLFormElement>) => {
+        if (isKeyEnter(e) && !isLogInPending) {
+            e.preventDefault()
+            e.currentTarget.requestSubmit()
+        }
+    }
 
     return (
-        <form className="p-3" onSubmit={handleSubmit} data-test-id="form-signin">
+        <form className="p-3" onSubmit={handleSubmit} onKeyDown={handleKeyDown} data-test-id="form-signin">
             <div className="form-floating mb-3">
                 <input
+                    ref={usernameRef}
                     type="text"
                     className="form-control"
                     id="username"
+                    name="username"
+                    autoComplete="username"
                     placeholder="Username"
                     value={username}
                     onChange={e => setUsername(e.target.value)}
@@ -48,9 +67,12 @@ function Signin({
             </div>
             <div className="form-floating mb-3">
                 <input
+                    ref={passwordRef}
                     type="password"
                     className="form-control"
                     id="password"
+                    name="password"
+                    autoComplete="current-password"
                     placeholder="Password"
                     value={password}
                     onChange={e => setPassword(e.target.value)}

--- a/code/frontend/src/login/components/Signup.tsx
+++ b/code/frontend/src/login/components/Signup.tsx
@@ -1,5 +1,6 @@
 import clsx from 'clsx'
-import React from 'react'
+import React, { useRef } from 'react'
+import { isKeyEnter } from '../../common/utils/keys'
 
 interface Props {
     switchToSignin: () => void
@@ -9,7 +10,7 @@ interface Props {
     setPassword: (password: string) => void
     passwordConfirmation: string
     setPasswordConfirmation: (passwordConfirmation: string) => void
-    signup: () => void
+    signup: (username: string, password: string) => void
     isLogInPending: boolean
     logInError: string | null
 }
@@ -26,27 +27,55 @@ function Signup({
     isLogInPending,
     logInError,
 }: Props) {
+    const usernameRef = useRef<HTMLInputElement>(null)
+    const passwordRef = useRef<HTMLInputElement>(null)
+    const passwordConfirmationRef = useRef<HTMLInputElement>(null)
+
     const handleSwitchToSignin = (e: React.MouseEvent) => {
         e.preventDefault()
         switchToSignin()
     }
 
-    const handleSubmit = (e: React.FormEvent) => {
-        e.preventDefault()
-        signup()
-    }
-
-    const isSubmitEnabled = username && password && passwordConfirmation && !isLogInPending
-
     const isPasswordConfirmationValid = password === passwordConfirmation
 
+    const handleSubmit = (e: React.FormEvent) => {
+        e.preventDefault()
+        const submittedUsername = usernameRef.current?.value ?? username
+        const submittedPassword = passwordRef.current?.value ?? password
+        const submittedConfirmation = passwordConfirmationRef.current?.value ?? passwordConfirmation
+        setUsername(submittedUsername)
+        setPassword(submittedPassword)
+        setPasswordConfirmation(submittedConfirmation)
+        if (
+            !submittedUsername ||
+            !submittedPassword ||
+            !submittedConfirmation ||
+            submittedPassword !== submittedConfirmation ||
+            isLogInPending
+        )
+            return
+        signup(submittedUsername, submittedPassword)
+    }
+
+    const isSubmitEnabled = !isLogInPending
+
+    const handleKeyDown = (e: React.KeyboardEvent<HTMLFormElement>) => {
+        if (isKeyEnter(e) && !isLogInPending) {
+            e.preventDefault()
+            e.currentTarget.requestSubmit()
+        }
+    }
+
     return (
-        <form className="p-3" onSubmit={handleSubmit}>
+        <form className="p-3" onSubmit={handleSubmit} onKeyDown={handleKeyDown}>
             <div className="form-floating mb-3">
                 <input
+                    ref={usernameRef}
                     type="text"
                     className="form-control"
                     id="username"
+                    name="username"
+                    autoComplete="username"
                     placeholder="Username"
                     value={username}
                     onChange={e => setUsername(e.target.value)}
@@ -55,9 +84,12 @@ function Signup({
             </div>
             <div className="form-floating mb-3">
                 <input
+                    ref={passwordRef}
                     type="password"
                     className="form-control"
                     id="password"
+                    name="password"
+                    autoComplete="new-password"
                     placeholder="Password"
                     value={password}
                     onChange={e => setPassword(e.target.value)}
@@ -66,11 +98,14 @@ function Signup({
             </div>
             <div className="form-floating mb-3">
                 <input
+                    ref={passwordConfirmationRef}
                     type="password"
                     className={clsx('form-control', {
                         'is-invalid': !isPasswordConfirmationValid,
                     })}
                     id="passwordConfirmation"
+                    name="passwordConfirmation"
+                    autoComplete="new-password"
                     placeholder="Confirm password"
                     value={passwordConfirmation}
                     onChange={e => setPasswordConfirmation(e.target.value)}

--- a/code/frontend/src/login/components/Signup.tsx
+++ b/code/frontend/src/login/components/Signup.tsx
@@ -1,5 +1,5 @@
 import clsx from 'clsx'
-import React, { useRef } from 'react'
+import { useRef } from 'react'
 import { isKeyEnter } from '../../common/utils/keys'
 
 interface Props {


### PR DESCRIPTION
- Read submitted values from input refs so autofill bypassing React onChange is captured
- Submit on Enter via explicit requestSubmit handler (fixes username field with iCloud Passwords)
- Keep submit button enabled (only disabled while pending)
- Add name/autocomplete attributes for password-manager integration