### PR TITLE
[docs] Add plans

### DIFF
--- a/.ralph/2026-07-02-mcp-oauth-spa-consent.md
+++ b/.ralph/2026-07-02-mcp-oauth-spa-consent.md
@@ -1,0 +1,187 @@
+# Plan: Serve the MCP OAuth consent step from the styled SPA
+
+## Problem
+
+The MCP OAuth authorization endpoint (`GET /authorize`) renders a hand-written, unstyled HTML
+consent form (`ConsentPageService`) that collects username/password plus Allow/Deny. It looks
+nothing like Dark Deeds. We want the consent step served by our own React SPA — same styling and
+login form — and to reuse an existing browser session when the user is already signed in, so an
+already-authenticated user only has to click once.
+
+Confirmed design decisions with the maintainer:
+1. Reuse the browser session: show a one-click **Authorize** screen (with the username) when the
+   user is already signed in; show the styled **login form** only when not signed in.
+2. Both paths end on ONE consistent explicit **Authorize** screen (with a Deny/Cancel option).
+3. The redirect target of `GET /authorize` is a **per-environment configured base URL**
+   (dev `http://localhost:3000`, prod same origin), mirroring the existing `OAuth:IssuerBaseUrl`
+   setting — required because in non-Production the backend serves Swagger at `/` and the SPA runs
+   on a separate origin (`:3000`), so a same-origin `/` redirect would not reach the SPA in dev.
+
+## Approach
+
+Turn `/authorize` into a thin redirect into the SPA and let the SPA drive consent and completion:
+
+- **`GET /authorize`** keeps its OAuth request validation, then 302-redirects to
+  `{OAuth:ConsentRedirectBaseUrl}/{query}` (preserving the original query string). The redirect URL
+  is built in the Domain layer because `OAuthSettings` is `internal` to `DD.ServiceAuth.Domain`.
+  `/token`, `/register`, `/.well-known`, `/mcp` stay backend-served; no `vite.config` denylist
+  change is needed.
+- **The SPA** detects the OAuth authorize request at bootstrap (`main.tsx`, by parsing the query)
+  and renders a dedicated styled consent flow instead of the tab app — isolated from the app's
+  task-hub / token-renewal hooks:
+  - Signed in (valid JWT in `localStorage`): one-click **Authorize** screen + Deny.
+  - Not signed in: the existing styled **login form** (`Signin`); on success the JWT is stored and
+    the flow lands on the SAME Authorize screen.
+- **Completion** (`POST /authorize`, JSON): the SPA sends its Bearer JWT and
+  `{ action, clientId, redirectUri, codeChallenge, state }`, receives `{ redirectUrl }`, and does
+  `window.location.assign(redirectUrl)` back to the MCP client. `allow` requires an authenticated
+  user (`IUserAuth`) and issues the auth code; `deny` returns `error=access_denied` and never
+  touches the user identity; `redirect_uri` is re-validated server-side (`IsAllowedRedirectUri`).
+  PKCE and issuer/host handling are unchanged.
+
+In dev the redirect lands on the Vite SPA at `:3000`; its `POST /authorize` back to `:5000` is
+already permitted by the dev CORS policy (`SetIsOriginAllowed(origin => origin.EndsWith(":3000"))`,
+`AllowAnyHeader`, `AllowCredentials`), so the full flow is verifiable locally.
+
+Task ordering keeps the backend solution building after EVERY task: add the config setting (and fix
+the `required`-member test initializers), add the completion DTOs, rework the flow (service +
+endpoints together), then delete the dead consent page; then the frontend parser/API, the optional
+`Signin` prop, the consent component, and finally the bootstrap branch. Frontend UI is verified by
+the mandatory local Selenium e2e regression run plus a curl smoke of the new endpoints — the project
+has no React Testing Library (tests are logic-only), matching the repo's existing test convention.
+
+## Validation
+
+Fast per-task gate — Ralph runs this after EVERY task. A clean build has **0 warnings** (warnings
+are treated as errors); fix them before moving on:
+
+```
+dotnet build code/backend/DarkDeeds.sln -c Release
+dotnet test code/backend/DarkDeeds.sln -c Release
+```
+
+Tasks that touch `code/frontend/**` additionally run the frontend gate (as their final checkbox):
+
+```
+cd code/frontend && npm run ci
+```
+
+## Todos
+
+### Task 1: Add the OAuth:ConsentRedirectBaseUrl setting and its wiring
+
+**Files:**
+- Modify: `code/backend/DD.ServiceAuth.Domain/OAuth/OAuthSettings.cs`
+- Modify: `code/backend/DD.App/appsettings.json`
+- Modify: `ci/infra/app.bicep`
+- Modify: `ci/infra/app.prod.parameters.json`
+- Modify: `code/backend/DD.Tests.Unit/ServiceAuth/TokenFlowTests.cs`
+- Modify: `code/backend/DD.Tests.Unit/ServiceAuth/RefreshTokenServiceTests.cs`
+
+- [ ] Add `[Required] public required string ConsentRedirectBaseUrl { get; init; }` to `OAuthSettings` (mirror the `IssuerBaseUrl` `CA1056` suppression)
+- [ ] In `appsettings.json` add `"ConsentRedirectBaseUrl": "http://localhost:3000"` under the `OAuth` section (dev default)
+- [ ] In `ci/infra/app.bicep` add `param oauthConsentRedirectBaseUrl string = ''` and an `OAuth__ConsentRedirectBaseUrl` app-setting entry set to that param (mirror `OAuth__IssuerBaseUrl`)
+- [ ] In `ci/infra/app.prod.parameters.json` add `"oauthConsentRedirectBaseUrl": { "value": "https://dark-deeds.com" }` (same origin as the issuer in prod)
+- [ ] Set `ConsentRedirectBaseUrl = "http://localhost:3000"` in both `OAuthSettings` initializers in `TokenFlowTests.cs` and `RefreshTokenServiceTests.cs` (the new member is `required`, so the test project will not compile otherwise)
+- [ ] Verify the fast checks pass with 0 warnings
+
+### Task 2: Add the OAuth consent completion DTOs
+
+**Files:**
+- Create: `code/backend/DD.ServiceAuth.Domain/OAuth/Dto/OAuthAuthorizeRequestDto.cs`
+- Create: `code/backend/DD.ServiceAuth.Domain/OAuth/Dto/OAuthRedirectResponseDto.cs`
+
+- [ ] Add `public sealed record OAuthAuthorizeRequestDto(string? Action, string? ClientId, string? RedirectUri, string? CodeChallenge, string? State);` (nullable members — bound from the SPA's camelCase JSON, validated manually in the controller; add the `CA1054` suppression used by sibling OAuth DTOs for the `RedirectUri` string)
+- [ ] Add `public sealed record OAuthRedirectResponseDto(string RedirectUrl);` (add the `CA1054` suppression consistent with siblings)
+- [ ] Verify the fast checks pass with 0 warnings
+
+### Task 3: Rework the /authorize flow to redirect into the SPA and complete via JSON
+
+**Files:**
+- Modify: `code/backend/DD.ServiceAuth.Domain/OAuth/Services/OAuthFlowService.cs`
+- Modify: `code/backend/DD.ServiceAuth.Details/Web/Controllers/OAuthController.cs`
+
+- [ ] In `IOAuthFlowService`/`OAuthFlowService` add `string BuildConsentRedirect(string queryString)` returning `$"{_oauthSettings.ConsentRedirectBaseUrl}/{queryString}"`
+- [ ] Replace `AuthorizeAsync(action, username, password, ...)` with `Task<string> BuildAuthorizeRedirectAsync(string action, string userId, string clientId, string redirectUri, string codeChallenge, string state)`: for `deny` return `oauthUrlService.BuildErrorRedirect(redirectUri, OAuthConstants.AccessDeniedError, state)`; for `allow` call `authCodeService.IssueAsync` for `userId` and return `oauthUrlService.BuildSuccessRedirect(...)` — drop the `authService.SignInAsync`/`GetUserIdAsync` calls; remove `RenderConsentPage` and the `IConsentPageService` constructor dependency
+- [ ] In `OAuthController`, change `GET /authorize` to `return Redirect(oauthFlowService.BuildConsentRedirect(Request.QueryString.Value ?? string.Empty))` after the existing validation (remove the `RenderConsentPage`/`Content(html, ...)` block)
+- [ ] Inject `IUserAuth` into `OAuthController`; make `POST /authorize` accept `[FromBody] OAuthAuthorizeRequestDto? request`, guard `request is null` and each required field (=> `BadRequest(OAuthErrorDto...)`), and re-validate `redirect_uri` via `IsAllowedRedirectUri` (=> `BadRequest`)
+- [ ] In `POST /authorize` branch on `action` FIRST: for `deny` build the error redirect without touching the user identity; only for `allow` require `userAuth.IsAuthenticated()` (else `return Unauthorized()`), then read `userAuth.UserId()`, call `BuildAuthorizeRedirectAsync`, and `return Ok(new OAuthRedirectResponseDto(location))` (never call `UserId()`/`AuthToken()` on an unauthenticated request — it throws)
+- [ ] Verify the fast checks pass with 0 warnings
+
+### Task 4: Delete the server-rendered consent page and its dead error DTOs
+
+**Files:**
+- Delete: `code/backend/DD.ServiceAuth.Domain/OAuth/Services/ConsentPageService.cs`
+- Modify: `code/backend/DD.ServiceAuth.Domain/Setup.cs`
+- Modify: `code/backend/DD.ServiceAuth.Domain/OAuth/Dto/OAuthErrorDto.cs`
+
+- [ ] Delete `ConsentPageService.cs` (the `IConsentPageService` interface and `ConsentPageService` class)
+- [ ] Remove `services.AddTransient<IConsentPageService, ConsentPageService>();` from `Setup.cs`
+- [ ] Remove the now-unused `OAuthErrorDto` entries `UsernameRequired`, `PasswordRequired`, and `CodeChallengeAndStateRequired` (confirm each is unreferenced via a repo search before deleting)
+- [ ] Verify the fast checks pass with 0 warnings
+
+### Task 5: Add the OAuth request parser, models, and completion API (frontend)
+
+**Files:**
+- Create: `code/frontend/src/oauth/models/OAuthAuthorizeRequest.ts`
+- Create: `code/frontend/src/oauth/models/OAuthAuthorizeResult.ts`
+- Create: `code/frontend/src/oauth/parseOAuthAuthorizeRequest.ts`
+- Create: `code/frontend/src/oauth/api/OAuthApi.ts`
+- Create: `code/frontend/tests/oauth/parseOAuthAuthorizeRequest.test.ts`
+
+- [ ] Define `interface OAuthAuthorizeRequest { clientId, redirectUri, codeChallenge, state, scope }` and a result union `{ status: 'redirect'; redirectUrl: string } | { status: 'needs-login' } | { status: 'error' }`
+- [ ] Implement `parseOAuthAuthorizeRequest(search: string): OAuthAuthorizeRequest | null` returning the typed request only when `response_type=code` and `client_id`, `redirect_uri`, `code_challenge`, `state` are all present, else `null`
+- [ ] Implement `OAuthApi.authorize(action: 'allow' | 'deny', request: OAuthAuthorizeRequest)` that `fetch`es `POST ${baseUrlProvider.getBaseUrl()}authorize` with JSON body `{ action, clientId, redirectUri, codeChallenge, state }` and `Authorization: Bearer ${storageService.loadAccessToken()}`; return `{ status: 'redirect', redirectUrl }` on 200, `{ status: 'needs-login' }` on 401, `{ status: 'error' }` otherwise; export an `oauthApi` singleton (mirror the `loginApi` pattern)
+- [ ] Add vitest cases for the parser: a valid query returns the parsed request; a missing/blank required param returns `null`; a normal app URL (no OAuth params) returns `null`
+- [ ] Verify `cd code/frontend && npm run ci` passes (run `npm run fmt` first if `fmt:check` fails)
+
+### Task 6: Make the Signin signup link optional (frontend)
+
+**Files:**
+- Modify: `code/frontend/src/login/components/Signin.tsx`
+
+- [ ] Add an optional `hideSignup?: boolean` prop; when true, render the sign-in form only (omit the "Sign up here" link) and make `switchToSignup` optional / guard its use so it is not required in that mode; leave the existing `Login` caller unchanged (prop defaults to showing signup)
+- [ ] Verify `cd code/frontend && npm run ci` passes
+
+### Task 7: Build the OAuthConsent flow component (frontend)
+
+**Files:**
+- Create: `code/frontend/src/oauth/OAuthConsent.tsx`
+- Create: `code/frontend/src/oauth/components/AuthorizePrompt.tsx`
+
+- [ ] `AuthorizePrompt`: a styled `Card` showing the requesting `clientId` and the signed-in `username`, with **Authorize** and **Deny** buttons and a submitting/disabled state (Bootstrap classes consistent with `Signin`)
+- [ ] `OAuthConsent`: take the parsed `OAuthAuthorizeRequest` as a prop; local phase state `login | authorize | submitting`; initialize to `authorize` when `authService.getCurrentUser()` returns a user, else `login`
+- [ ] Login phase: render `Signin` with `hideSignup`, wired to local username/password state, the existing `signin` login thunk, and the `login` slice `isLogInPending`/`logInError`; on `SigninResultEnum.Success` call `storageService.saveAccessToken(token)` and switch to `authorize`
+- [ ] Authorize phase: render `AuthorizePrompt`; Authorize => `oauthApi.authorize('allow', request)`, Deny => `oauthApi.authorize('deny', request)`; on `redirect` do `window.location.assign(redirectUrl)`; on `needs-login` switch back to `login`; on `error` show an inline alert
+- [ ] Verify `cd code/frontend && npm run ci` passes
+
+### Task 8: Branch the app bootstrap into the OAuth consent flow (frontend)
+
+**Files:**
+- Modify: `code/frontend/src/main.tsx`
+
+- [ ] Compute `const oauthRequest = parseOAuthAuthorizeRequest(window.location.search)` before rendering
+- [ ] Render `<OAuthConsent request={oauthRequest} />` inside the existing `<Provider store={store}>` when `oauthRequest` is non-null, otherwise render `<App />` exactly as today (normal app behavior must be unchanged when there are no OAuth params)
+- [ ] Verify `cd code/frontend && npm run ci` passes
+
+### Task 9: Final validation
+
+- [ ] Build the whole backend solution with 0 warnings: `dotnet build code/backend/DarkDeeds.sln -c Release`
+- [ ] Run the full backend unit suite: `dotnet test code/backend/DarkDeeds.sln -c Release`
+- [ ] Run the full frontend gate: `cd code/frontend && npm run ci`
+- [ ] Bring up the full local stack (see the local-run workflow in `.github/copilot-instructions.md`) as detached background processes (never piped to `head`/`tail`), recording each PID: MongoDB via `./infra/up.sh`; the backend `dotnet run --project code/backend/DD.App` on `:5000` (wait for `curl -fsS http://localhost:5000/healthcheck` => `Healthy`); the frontend `cd code/frontend && npm run dev` on `:3000` (wait for HTTP 200)
+- [ ] curl smoke on `:5000`: `GET "/authorize?response_type=code&client_id=x&redirect_uri=http://127.0.0.1:33418&code_challenge=abc&code_challenge_method=S256&state=xyz"` returns 302 with `Location` starting `http://localhost:3000/?` and preserving the query; then `POST /api/auth/account/signin` (test/test) to obtain a JWT, and `POST /authorize` with that Bearer and `{"action":"allow", ...}` returns `{ redirectUrl }` containing `code=` and `state=`, while `{"action":"deny", ...}` returns a `redirectUrl` containing `error=access_denied`
+- [ ] Run the e2e suite against the local stack and confirm ALL pass: `dotnet test code/tests/DarkDeeds.E2eTests` (defaults `URL=http://localhost:3000` / `BE_URL=http://localhost:5000`; uses a local ChromeDriver, so Chrome must be installed)
+- [ ] Fix any failure and re-run until the backend build/tests, the frontend `npm run ci`, the curl smokes, and the whole e2e suite are ALL green; then tear down the backend and frontend you started (stop each by PID; leave MongoDB running)
+
+## Notes
+
+- The full browser click-through of the OAuth consent (external redirect to a loopback MCP client)
+  is verified manually outside Ralph, as in the prior MCP OAuth plan; the curl smokes above cover
+  the `GET` redirect and the `allow`/`deny` completion automatically.
+- The dev cross-origin completion (`:3000` SPA => `:5000` backend) relies on the existing dev CORS
+  policy in `Startup.cs`; no CORS change is needed.
+- No `vite.config` `navigateFallbackDenylist` change is needed; `/authorize`, `/token`, `/register`,
+  `/.well-known`, `/mcp` stay backend-served and the redirect goes to the configured SPA base URL.
+- Everything committed stays in English; do not modify any `// important`-marked code without
+  approval.

--- a/.ralph/2026-07-02-scope-mcp-token-audience.md
+++ b/.ralph/2026-07-02-scope-mcp-token-audience.md
@@ -1,0 +1,126 @@
+# Plan: Scope MCP OAuth tokens to the /mcp endpoint
+
+## Problem
+
+Dark Deeds issues JWT access tokens two ways: the regular web/login flow
+(`AccountController` => `AuthService.SignIn/SignUp/RenewToken`) and the OAuth/MCP flow
+(`OAuthController.Token` => `OAuthFlowService.IssueTokensAsync` =>
+`AuthService.CreateAccessTokenAsync`). Both mint the token through the same
+`TokenService.Serialize`, which hardcodes `Issuer = Auth:Issuer` and
+`Audience = Auth:Audience`; the two tokens differ only in lifetime. A single `JwtBearer`
+scheme validates every request (`ValidAudience = Auth:Audience`) and `/mcp` forwards
+authentication to that same scheme (`AddMcp ForwardAuthenticate = JwtBearer`).
+
+As a result, a token obtained through the MCP OAuth flow is accepted on every
+authenticated endpoint (tasks API, `/ws`, account renew), not just MCP tool calls. We
+want an MCP token usable **only** for MCP tool calls (`MapMcp("/mcp")`).
+
+## Approach
+
+Resource-scope the OAuth access token by JWT **audience** and validate `/mcp` with a
+**dedicated bearer scheme** bound to that audience:
+
+- OAuth-issued access tokens get a distinct audience `dd-oauth-access` instead of the
+  shared `Auth:Audience`. All user claims (`sub`/`name`/`given_name`/`jti`/`exp`) are
+  unchanged, so `ClaimsService`/`UserAuth` user resolution keeps working. Issuer stays
+  `Auth:Issuer` — only the audience discriminates (the standard "who the token is for" =
+  the resource).
+- A second `JwtBearer` scheme (`McpBearer`) is identical to the default one but validates
+  `ValidAudience = dd-oauth-access`. The `/mcp` endpoint authenticates with it via
+  `AddMcp ForwardAuthenticate = McpBearer`; its challenge still comes from
+  `McpAuthenticationDefaults`, so protected-resource-metadata discovery is unchanged.
+
+Net effect (clean bidirectional separation): an MCP token (aud `dd-oauth-access`) is valid
+at `/mcp` and rejected (401) everywhere else; a login token (aud `Auth:Audience`) is valid
+on the app endpoints and rejected (401) at `/mcp`. No new configuration is required (the
+audience is a compile-time invariant, like the existing internal `OAuthTokenKinds`
+audiences), so `appsettings`/bicep/dedicated-host config is untouched.
+
+## Validation
+
+Fast per-task gate (repo rule — run after every task; a clean build has **0 warnings**,
+which are treated as errors):
+
+```
+dotnet build code/backend/DarkDeeds.sln -c Release
+dotnet test code/backend/DarkDeeds.sln -c Release
+```
+
+## Todos
+
+### Task 1: Issue OAuth access tokens with a distinct MCP audience
+
+**Files:**
+- Modify: `code/backend/DD.ServiceAuth.Domain/OAuth/OAuthConstants.cs`
+- Modify: `code/backend/DD.ServiceAuth.Domain/Services/TokenService.cs`
+- Modify: `code/backend/DD.ServiceAuth.Domain/Services/AuthService.cs`
+
+- [ ] In `OAuthConstants`, add `public const string AccessTokenAudience = "dd-oauth-access";` with a short comment explaining it is the audience that scopes OAuth access tokens to the MCP resource (public because the JwtBearer setup in `DD.ServiceAuth.Details` must reference it).
+- [ ] In `ITokenService.Serialize` and `TokenService.Serialize`, add an optional `string? audience = null` parameter and set the descriptor `Audience = audience ?? _authSettings.Audience` (mirrors the existing optional `lifetimeMinutes`).
+- [ ] In `AuthService.CreateAccessTokenAsync`, pass `OAuthConstants.AccessTokenAudience` as the audience to `tokenService.Serialize` (add `using DD.ServiceAuth.Domain.OAuth;` if needed). The sign-in/sign-up/renew paths keep the default `Auth:Audience`.
+- [ ] Verify the fast checks pass.
+
+### Task 2: Validate `/mcp` with a dedicated MCP bearer scheme
+
+**Files:**
+- Modify: `code/backend/DD.ServiceAuth.Details/Setup.cs`
+
+- [ ] Add `using DD.ServiceAuth.Domain.OAuth;` to `Setup.cs` (so `OAuthConstants.AccessTokenAudience` resolves) and a `private const string McpJwtBearerScheme = "McpBearer";` to the `Setup` class.
+- [ ] Register a second `.AddJwtBearer(McpJwtBearerScheme, options => …)` with the same `RequireHttpsMetadata`, `MapInboundClaims = false`, signing key, `ValidIssuer = authSettings.Issuer`, and `ValidateLifetime` as the default scheme, but `ValidAudience = OAuthConstants.AccessTokenAudience`. Do NOT add the `/ws` `OnMessageReceived` query-token event to this scheme.
+- [ ] Change the `.AddMcp(...)` `options.ForwardAuthenticate` from `JwtBearerDefaults.AuthenticationScheme` to `McpJwtBearerScheme`.
+- [ ] Update the stale comment above `ForwardAuthenticate` (it currently says `/mcp` accepts the same access token) to explain `/mcp` now only accepts the `dd-oauth-access` audience.
+- [ ] Verify the fast checks pass.
+
+### Task 3: Cover the audience split with unit tests
+
+**Files:**
+- Modify: `code/backend/DD.Tests.Unit/ServiceAuth/TokenFlowTests.cs`
+- Create: `code/backend/DD.Tests.Unit/ServiceAuth/TokenServiceTests.cs`
+
+- [ ] In `TokenFlowTests`, serialize the access token with `OAuthConstants.AccessTokenAudience` and validate it with `ValidAudience = OAuthConstants.AccessTokenAudience`, so the test mirrors `AuthService.CreateAccessTokenAsync`.
+- [ ] Add a `TokenServiceTests` test asserting `Serialize(buildInfo, audience: OAuthConstants.AccessTokenAudience)` produces a JWT whose `aud` claim equals `dd-oauth-access`.
+- [ ] Add a `TokenServiceTests` test asserting `Serialize(buildInfo)` with no audience produces a JWT whose `aud` claim equals the configured `Auth:Audience`.
+- [ ] Verify the fast checks pass.
+
+### Task 4: Verify the audience split against a live backend
+
+**Files:**
+- (no source changes — live verification of the running app)
+
+- [ ] Ensure MongoDB is up (`./infra/up.sh`) and start `DD.App` on `:5000` as a detached background process (log to a file, capture the PID); wait until `curl -fsS http://localhost:5000/healthcheck` returns `Healthy`.
+- [ ] Bootstrap credentials on the fresh database: `POST http://localhost:5000/api/test/CreateTestUser` returns JSON `{ "userId", "username", "password" }`; use the returned `username`/`password` in the steps below (there is no pre-seeded `test`/`test` user).
+- [ ] Get a login token: `POST http://localhost:5000/api/auth/Account/SignIn` with `{"Username":"<username>","Password":"<password>"}` and capture the returned `token`. Confirm `GET "http://localhost:5000/api/task/Tasks?from=2000-01-01T00:00:00Z"` with header `Authorization: Bearer <token>` returns **200** (login token works on the app API) and `POST http://localhost:5000/mcp` with the same Bearer returns **401** (login token rejected at `/mcp`).
+- [ ] Mint an MCP access token via the OAuth authorization_code + PKCE flow using the known test PKCE pair (verifier `dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk`, challenge `E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM`), a loopback `redirect_uri=http://127.0.0.1:5000/callback`, a fixed `client_id` (e.g. `smoke-client`) and the created user's creds: `POST http://localhost:5000/authorize` as form data `action=allow&username=<username>&password=<password>&client_id=smoke-client&redirect_uri=http://127.0.0.1:5000/callback&code_challenge=E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM&state=xyz`, read `code` from the `302` `Location` header, then `POST http://localhost:5000/token` as form data `grant_type=authorization_code&code=<code>&redirect_uri=http://127.0.0.1:5000/callback&client_id=smoke-client&code_verifier=dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk` and capture `access_token`.
+- [ ] Confirm the MCP token is **rejected on the app API** — `GET "http://localhost:5000/api/task/Tasks?from=2000-01-01T00:00:00Z"` with `Authorization: Bearer <access_token>` returns **401** — and **accepted at `/mcp`** — `POST http://localhost:5000/mcp` with headers `Authorization: Bearer <access_token>`, `Content-Type: application/json`, `Accept: application/json, text/event-stream` and body `{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"smoke","version":"1"}}}` returns a non-401 success (200).
+- [ ] Stop the `DD.App` process by PID (leave MongoDB running).
+
+### Task 5: Final validation (full pass + local e2e)
+
+**Files:**
+- (no source changes — mandated final gate)
+
+- [ ] Build the whole backend solution with no warnings: `dotnet build code/backend/DarkDeeds.sln -c Release`.
+- [ ] Run the full backend unit suite: `dotnet test code/backend/DarkDeeds.sln -c Release`.
+- [ ] Run the full frontend gate: `cd code/frontend && npm run ci`.
+- [ ] Bring up the full local stack: MongoDB via `./infra/up.sh`, backend `dotnet run --project code/backend/DD.App` on `:5000` (detached; wait for `curl -fsS http://localhost:5000/healthcheck` => `Healthy`), frontend `cd code/frontend && npm run dev` on `:3000` (detached; wait for HTTP 200). Start the servers as detached background processes, never piped to `head`/`tail`.
+- [ ] Run the e2e suite against the local stack and confirm **ALL** tests pass: `dotnet test code/tests/DarkDeeds.E2eTests` (defaults `URL=http://localhost:3000` / `BE_URL=http://localhost:5000`; uses a local ChromeDriver, so Chrome must be installed).
+- [ ] Fix any e2e failure and re-run until the whole e2e suite is green, then tear down the backend and frontend you started (stop each by PID; leave MongoDB running).
+
+## Notes
+
+- **No new configuration**: the `dd-oauth-access` audience is a compile-time invariant
+  (like the internal `OAuthTokenKinds` authcode/refresh audiences), so no
+  `appsettings`/bicep/dedicated-host changes are needed.
+- **Constant placement**: `dd-oauth-access` goes in the public `OAuthConstants` because
+  validation lives in `DD.ServiceAuth.Details` (which references `DD.ServiceAuth.Domain`);
+  a public member cannot live in the internal `OAuthTokenKinds` class. A dedicated public
+  class is an acceptable alternative.
+- **Transition window**: MCP access tokens issued before deploy carry the old
+  `Auth:Audience` and will be rejected at `/mcp` until the client refreshes; refresh
+  tokens keep working and mint a new `dd-oauth-access` token. Access-token lifetime is
+  60 min, so the window is small.
+- **MCP surface**: the only MCP endpoint is `MapMcp("/mcp")`, wired in
+  `code/backend/DD.Clients.Details/Setup.cs` (there is no separate `McpController`). The
+  regular app endpoints, `/ws`, and this `/mcp` endpoint are the surfaces affected by the
+  audience split.
+- Everything committed is in English; no `// important`-marked code is modified.


### PR DESCRIPTION
- Plan for serving the MCP OAuth consent step from the styled React SPA
- Plan for scoping MCP OAuth access tokens to the /mcp endpoint by audience