### PR TITLE
[fix] Refine terminal UI refresh and focus

### DIFF
--- a/code/backend/DD.TerminalClient.Details/Ui/OverviewRenderer.cs
+++ b/code/backend/DD.TerminalClient.Details/Ui/OverviewRenderer.cs
@@ -134,7 +134,7 @@ public static class OverviewRenderer
     private static Text DayHeaderLine(OverviewDay day, DateOnly today, int width)
     {
         var label = day.Date is { } date
-            ? date.ToString("ddd dd MMM", CultureInfo.InvariantCulture)
+            ? date.ToString("MM/dd ddd", CultureInfo.InvariantCulture)
             : "No Date";
         var isToday = day.Date is { } value && value == today;
         var style = isToday ? TerminalStyles.Today : TerminalStyles.DayHeader;
@@ -144,7 +144,8 @@ public static class OverviewRenderer
     private static Text CollapsedRoutineLine(int count, int width)
     {
         var label = "    +" + count.ToString(CultureInfo.InvariantCulture) + " routine";
-        return new Text(TerminalText.Truncate(label, width), TerminalStyles.Hint);
+        var style = count == 0 ? TerminalStyles.CompletedHint : TerminalStyles.Hint;
+        return new Text(TerminalText.Truncate(label, width), style);
     }
 
     private static void AppendCardSeparator(List<IRenderable> lines)

--- a/code/backend/DD.TerminalClient.Details/Ui/TerminalStyles.cs
+++ b/code/backend/DD.TerminalClient.Details/Ui/TerminalStyles.cs
@@ -17,6 +17,8 @@ internal static class TerminalStyles
 
     public static readonly Style Hint = new(Color.Grey);
 
+    public static readonly Style CompletedHint = new(Color.Grey, decoration: Decoration.Dim);
+
     public static readonly Style EmptyState = new(Color.Grey, decoration: Decoration.Italic);
 
     // Composes the style for one rendered task line from its type, completion, probability and focus.

--- a/code/backend/DD.TerminalClient.Domain/Application/ApplicationReducer.cs
+++ b/code/backend/DD.TerminalClient.Domain/Application/ApplicationReducer.cs
@@ -44,7 +44,7 @@ public sealed class ApplicationReducer(
                 .ToHashSet()
             : NoRoutineDates;
         var projected = projection.Project(state.Cache, state.ShowCompleted, routineShownDates);
-        var focus = TaskFocusService.Reconcile(projected, state.Focus);
+        var focus = TaskFocusService.Reconcile(projected, state.Focus, projection.Today);
         return state with { Projection = projected, Focus = focus };
     }
 

--- a/code/backend/DD.TerminalClient.Domain/Navigation/TaskFocusService.cs
+++ b/code/backend/DD.TerminalClient.Domain/Navigation/TaskFocusService.cs
@@ -5,8 +5,8 @@ namespace DD.TerminalClient.Domain.Navigation;
 // Pure focus resolution over the Overview grid, run after every re-projection so keyboard focus stays
 // on a real visible task. It is deliberate about which task keeps focus:
 //
-//   - ResolveInitial picks the first visible task in reading order (No Date, then Overdue, Current and
-//     Future; each section top to bottom, left to right), or null when nothing is visible.
+//   - ResolveInitial prefers the first visible task on the requested date, then falls back to reading
+//     order (No Date, then Overdue, Current and Future; each section top to bottom, left to right).
 //   - Reconcile preserves the focused task by Uid, so an edit, an explicit date move, a Routine
 //     expand or a server-wins conflict that keeps the same Uid simply follows the task to its new
 //     address. When the focused Uid is gone (deleted, completed-filtered, Routine-collapsed, removed
@@ -16,15 +16,18 @@ namespace DD.TerminalClient.Domain.Navigation;
 //     none and content now exists, and returns null only when nothing is visible.
 public static class TaskFocusService
 {
-    public static TaskFocus? ResolveInitial(OverviewProjection projection)
+    public static TaskFocus? ResolveInitial(OverviewProjection projection, DateOnly? preferredDate = null)
     {
         ArgumentNullException.ThrowIfNull(projection);
 
-        var first = OrderedTasks(projection).FirstOrDefault();
+        var first = InitialTask(OrderedTasks(projection), preferredDate);
         return first is null ? null : ToFocus(first);
     }
 
-    public static TaskFocus? Reconcile(OverviewProjection projection, TaskFocus? previous)
+    public static TaskFocus? Reconcile(
+        OverviewProjection projection,
+        TaskFocus? previous,
+        DateOnly? preferredInitialDate = null)
     {
         ArgumentNullException.ThrowIfNull(projection);
 
@@ -32,9 +35,9 @@ public static class TaskFocusService
         if (ordered.Count == 0)
             return null;
 
-        // No prior focus (startup or everything was hidden) but content exists: focus the first task.
+        // No prior focus (startup or everything was hidden) but content exists: prefer today's first task.
         if (previous is null)
-            return ToFocus(ordered[0]);
+            return ToFocus(InitialTask(ordered, preferredInitialDate)!);
 
         // Uid preservation: follow the same task wherever it now lives.
         var preserved = ordered.FirstOrDefault(task =>
@@ -62,6 +65,13 @@ public static class TaskFocusService
         // else the last remaining task.
         var after = ordered.FirstOrDefault(task => CompareAddress(task.Address, old) >= 0);
         return after ?? ordered[^1];
+    }
+
+    private static OverviewTask? InitialTask(List<OverviewTask> ordered, DateOnly? preferredDate)
+    {
+        return preferredDate is { } date
+            ? ordered.FirstOrDefault(task => task.Task.Date == date) ?? ordered.FirstOrDefault()
+            : ordered.FirstOrDefault();
     }
 
     // Every visible task in reading order. AllCells is globally ordered by (Section, Row, Column) and

--- a/code/backend/DD.TerminalClient.Domain/Overview/OverviewProjectionService.cs
+++ b/code/backend/DD.TerminalClient.Domain/Overview/OverviewProjectionService.cs
@@ -12,6 +12,8 @@ public sealed class OverviewProjectionService(ILocalDateProvider localDateProvid
     private const int VisibleColumns = 7;
     private const int CurrentDayCount = 14;
 
+    public DateOnly Today => localDateProvider.Today;
+
     // Builds the projection. showCompleted toggles completed-task visibility everywhere; routineShownDates
     // are the dated days whose Routine tasks stay expanded (every other dated day collapses them).
     public OverviewProjection Project(

--- a/code/backend/DD.TerminalClient/TerminalApplication.cs
+++ b/code/backend/DD.TerminalClient/TerminalApplication.cs
@@ -109,6 +109,11 @@ internal sealed class TerminalApplication
         return _channel.Writer.TryWrite(applicationEvent);
     }
 
+    internal static bool ShouldRenderHeartbeat(bool isOffline)
+    {
+        return isOffline;
+    }
+
     private async Task EventLoopAsync()
     {
         while (!State.Quit)
@@ -118,20 +123,24 @@ internal sealed class TerminalApplication
                 break;
             }
 
+            var shouldRender = false;
             while (_channel.Reader.TryRead(out var applicationEvent))
             {
-                Process(applicationEvent);
+                shouldRender |= Process(applicationEvent);
                 if (State.Quit)
                 {
                     break;
                 }
             }
 
-            Render();
+            if (shouldRender)
+            {
+                Render();
+            }
         }
     }
 
-    private void Process(ApplicationEvent applicationEvent)
+    private bool Process(ApplicationEvent applicationEvent)
     {
         switch (applicationEvent.Kind)
         {
@@ -142,8 +151,7 @@ internal sealed class TerminalApplication
                 State = ApplicationReducer.HandleResize(State, applicationEvent.Width, applicationEvent.Height);
                 break;
             case ApplicationEventKind.Hub:
-                HandleHub(applicationEvent.Hub!);
-                break;
+                return HandleHub(applicationEvent.Hub!);
             case ApplicationEventKind.SnapshotLoaded:
                 HandleSnapshotLoaded(applicationEvent.Tasks, applicationEvent.Generation);
                 break;
@@ -189,6 +197,8 @@ internal sealed class TerminalApplication
             default:
                 break;
         }
+
+        return true;
     }
 
     private void HandleKey(ConsoleKeyInfo key)
@@ -273,7 +283,7 @@ internal sealed class TerminalApplication
         State = _deps.Reducer.Recompute(State);
     }
 
-    private void HandleHub(TaskHubEvent hubEvent)
+    private bool HandleHub(TaskHubEvent hubEvent)
     {
         switch (hubEvent.Kind)
         {
@@ -283,6 +293,11 @@ internal sealed class TerminalApplication
                 PersistState();
                 break;
             case TaskHubEventKind.Heartbeat:
+                if (!ShouldRenderHeartbeat(State.IsOffline))
+                {
+                    return false;
+                }
+
                 State = State with { IsOffline = false };
                 break;
             case TaskHubEventKind.Reconnecting:
@@ -298,6 +313,8 @@ internal sealed class TerminalApplication
                 Handle401();
                 break;
         }
+
+        return true;
     }
 
     private void HandleSnapshotLoaded(IReadOnlyList<TerminalTask> tasks, int generation)

--- a/code/backend/DD.Tests.Unit/TerminalClient/OverviewRendererTests.cs
+++ b/code/backend/DD.Tests.Unit/TerminalClient/OverviewRendererTests.cs
@@ -55,7 +55,7 @@ public sealed class OverviewRendererTests
         Assert.Contains("Old thing", contentOutput, StringComparison.Ordinal);
         Assert.Contains("Today thing", contentOutput, StringComparison.Ordinal);
         Assert.Contains("Later thing", contentOutput, StringComparison.Ordinal);
-        Assert.Contains("Mon 04 Nov", contentOutput, StringComparison.Ordinal);
+        Assert.Contains("11/04 Mon", contentOutput, StringComparison.Ordinal);
         Assert.Contains("? help", output, StringComparison.Ordinal);
     }
 
@@ -165,7 +165,7 @@ public sealed class OverviewRendererTests
 
         var output = Ansi(new Rows(OverviewRenderer.Render(Vm(projection), 80).Lines), 80);
 
-        Assert.Contains("Tue 05 Nov", output, StringComparison.Ordinal);
+        Assert.Contains("11/05 Tue", output, StringComparison.Ordinal);
         Assert.DoesNotContain("--", output, StringComparison.Ordinal);
         Assert.Contains("[1;38;5;12m", output, StringComparison.Ordinal);
     }
@@ -206,10 +206,14 @@ public sealed class OverviewRendererTests
             showCompleted: false,
             routineShownDates: new HashSet<DateOnly>());
         var console = Plain(80);
+        var rendered = new Rows(OverviewRenderer.Render(Vm(projection), 80).Lines);
 
-        console.Write(new Rows(OverviewRenderer.Render(Vm(projection), 80).Lines));
+        console.Write(rendered);
+        var ansi = Ansi(rendered, 80);
 
         Assert.Contains("+0 routine", console.Output, StringComparison.Ordinal);
+        Assert.Contains("[2;38;5;8m", ansi, StringComparison.Ordinal);
+        Assert.DoesNotContain("[9;", ansi, StringComparison.Ordinal);
     }
 
     [Theory]

--- a/code/backend/DD.Tests.Unit/TerminalClient/TaskNavigationServiceTests.cs
+++ b/code/backend/DD.Tests.Unit/TerminalClient/TaskNavigationServiceTests.cs
@@ -407,6 +407,18 @@ public sealed class TaskNavigationServiceTests
         Assert.Equal("overdue", TaskFocusService.ResolveInitial(projection)!.Uid);
     }
 
+    [Fact]
+    public void ResolveInitial_PreferredDate_PicksItsFirstTask()
+    {
+        var projection = Project([
+            Task("nodate", date: null),
+            Task("today-first", Monday, order: 1),
+            Task("today-second", Monday, order: 2),
+        ]);
+
+        Assert.Equal("today-first", TaskFocusService.ResolveInitial(projection, Monday)!.Uid);
+    }
+
     // --- Focus reconciliation -------------------------------------------------------------------
     [Fact]
     public void Reconcile_NoPreviousFocus_WithContent_EstablishesInitialFocus()
@@ -414,6 +426,17 @@ public sealed class TaskNavigationServiceTests
         var projection = Project([Task("first", Monday)]);
 
         Assert.Equal("first", TaskFocusService.Reconcile(projection, previous: null)!.Uid);
+    }
+
+    [Fact]
+    public void Reconcile_NoPreviousFocus_PrefersRequestedDate()
+    {
+        var projection = Project([
+            Task("nodate", date: null),
+            Task("today", Monday),
+        ]);
+
+        Assert.Equal("today", TaskFocusService.Reconcile(projection, previous: null, Monday)!.Uid);
     }
 
     [Fact]

--- a/code/backend/DD.Tests.Unit/TerminalClient/TerminalApplicationTests.cs
+++ b/code/backend/DD.Tests.Unit/TerminalClient/TerminalApplicationTests.cs
@@ -465,6 +465,13 @@ public sealed class TerminalApplicationTests
     }
 
     [Fact]
+    public void ShouldRenderHeartbeat_ReturnsTrueOnlyWhenConnectivityChanges()
+    {
+        Assert.True(TerminalApplication.ShouldRenderHeartbeat(isOffline: true));
+        Assert.False(TerminalApplication.ShouldRenderHeartbeat(isOffline: false));
+    }
+
+    [Fact]
     public async Task Unauthorized_PreservesDurableOutbox()
     {
         using var harness = new Harness();


### PR DESCRIPTION
- Avoid repainting the screen for no-op SignalR heartbeats
- Focus the first task for today and use compact date headers
- Dim completed collapsed-routine summaries without striking them through