### PR TITLE
[fix] Stabilize terminal rendering and status display

### DIFF
--- a/.github/instructions/custom-rules.instructions.md
+++ b/.github/instructions/custom-rules.instructions.md
@@ -29,6 +29,8 @@ Rules specific to this repository. **If a rule is here — follow it. No excepti
 
 **For mixed styles on one terminal line, use a custom `Renderable` that emits separate `Segment`s.** The repository's Spectre.Console version applies only one style per `Text` and does not support a styled `Text.Append` overload.
 
+**Wrap every full-screen alternate-buffer redraw in DEC synchronized output (`CSI ? 2026 h` / `CSI ? 2026 l`) and release it in a `finally` block.** Clearing before sequentially writing the header, content, and footer otherwise exposes partial frames as visible flicker during ordinary keyboard navigation.
+
 **When copying or re-emitting Spectre `Segment`s (e.g. clipping the terminal viewport), copy a `SegmentLine` with `list.AddRange(segmentLine)` or `foreach`, never the collection-expression spread `[.. segmentLine]`.** The spread injects `null` padding segments into the copy, which later throw `NullReferenceException` deep inside `Spectre.Console.Rendering.Segment.Merge` when the output is written. An empty `[]` is safe; only spreading a non-empty `SegmentLine` is affected.
 
 **Render terminal day cards as one top-to-bottom stream with a blank line between cards, but no trailing blank line after the final card.** Up/Down navigates the immediately previous/next visible task across all sections; Left/Right navigates the previous/next non-empty rendered day and lands on its first task.

--- a/code/backend/DD.TerminalClient.Details/Ui/TerminalFrame.cs
+++ b/code/backend/DD.TerminalClient.Details/Ui/TerminalFrame.cs
@@ -10,8 +10,8 @@ namespace DD.TerminalClient.Details.Ui;
 // keymap, or an empty-state message), and a fixed status footer. The footer reflects the current mode
 // without ever running a Spectre prompt inside the live display: it draws the supplied editor/login
 // buffer and cursor as ordinary styled text, shows the delete confirmation question, the full focused
-// task text in Normal mode, and the offline and conflict notifications. All user-supplied text (titles,
-// profile name, notifications, editor buffer) is escaped so it can never be interpreted as markup.
+// task text in Normal mode, and conflict/action notifications. All user-supplied text (titles, profile
+// name, connection URL, notifications, editor buffer) is escaped so it can never be interpreted as markup.
 public static class TerminalFrame
 {
     public static IRenderable Render(TerminalViewModel model, int width)
@@ -36,7 +36,9 @@ public static class TerminalFrame
             right.Add("[grey]completed shown[/]");
         }
 
-        right.Add(model.IsOffline ? "[red bold]offline[/]" : "[green]online[/]");
+        right.Add(model.IsOffline
+            ? "[red bold]offline[/] [grey](cached tasks)[/]"
+            : "[green]online[/]");
 
         var grid = new Grid { Expand = true };
         grid.AddColumn(new GridColumn().NoWrap());
@@ -51,7 +53,7 @@ public static class TerminalFrame
 
         if (model.Status.Kind == TerminalStatusKind.Help)
         {
-            return RenderHelp();
+            return RenderHelp(model);
         }
 
         var overview = OverviewRenderer.Render(model, width);
@@ -68,11 +70,6 @@ public static class TerminalFrame
         ArgumentNullException.ThrowIfNull(model);
 
         var body = new List<IRenderable>();
-
-        if (model.IsOffline)
-        {
-            body.Add(new Markup("[red bold]OFFLINE[/] [grey]showing cached tasks[/]"));
-        }
 
         if (model.Notification is { } notification && !string.IsNullOrWhiteSpace(notification))
         {
@@ -109,7 +106,7 @@ public static class TerminalFrame
             .BorderColor(Color.Grey);
     }
 
-    private static Panel RenderHelp()
+    private static Panel RenderHelp(TerminalViewModel model)
     {
         var grid = new Grid();
         grid.AddColumn(new GridColumn().NoWrap().PadRight(3));
@@ -129,6 +126,13 @@ public static class TerminalFrame
         AddHelpRow(grid, "Ctrl+R", "Reconnect and reload");
         AddHelpRow(grid, "?", "Toggle this help");
         AddHelpRow(grid, "q", "Quit");
+
+        if (!string.IsNullOrWhiteSpace(model.ConnectionUrl))
+        {
+            grid.AddEmptyRow();
+            grid.AddRow(new Markup("[bold]Debug[/]"), new Text(string.Empty));
+            AddHelpRow(grid, "Server", model.ConnectionUrl);
+        }
 
         return new Panel(grid)
             .Header(" Keyboard shortcuts ")

--- a/code/backend/DD.TerminalClient.Details/Ui/TerminalViewModel.cs
+++ b/code/backend/DD.TerminalClient.Details/Ui/TerminalViewModel.cs
@@ -23,5 +23,7 @@ public sealed record TerminalViewModel
 
     public string ProfileName { get; init; } = string.Empty;
 
+    public string? ConnectionUrl { get; init; }
+
     public TerminalStatus Status { get; init; } = new();
 }

--- a/code/backend/DD.TerminalClient/Program.cs
+++ b/code/backend/DD.TerminalClient/Program.cs
@@ -141,6 +141,9 @@ internal static class Program
             SetToken = SetToken,
             ReadDimensions = () => ViewportRenderable.ResolveDimensions(console, ViewportRenderable.ReadWindowSize),
             ProfileName = profile.Name,
+            ConnectionUrl = string.Equals(profile.Name, "production", StringComparison.OrdinalIgnoreCase)
+                ? null
+                : profile.BaseUri.AbsoluteUri,
         };
 
         using var cts = new CancellationTokenSource();

--- a/code/backend/DD.TerminalClient/SpectreTerminalRenderer.cs
+++ b/code/backend/DD.TerminalClient/SpectreTerminalRenderer.cs
@@ -6,15 +6,17 @@ using Spectre.Console.Rendering;
 namespace DD.TerminalClient;
 
 // The production terminal surface: an alternate-screen, full-frame renderer driven by the event loop.
-// Begin switches to the alternate buffer and hides the cursor; End restores both. Each Render clears the
-// buffer and writes a fixed header, the scrollable Overview (or help/empty content) clipped into a
-// viewport that keeps the focused task visible, and a fixed footer - or the resize-required screen when
-// the terminal is below the supported minimum. It never runs a Spectre prompt inside the live frame and
-// never logs, so the alternate screen stays the sole owner of the console.
+// Begin switches to the alternate buffer and hides the cursor; End restores both. Each Render replaces
+// the buffer inside a synchronized terminal update, so clearing and writing the header, viewport and
+// footer become visible as one frame instead of flickering through partial output. It never runs a
+// Spectre prompt inside the live frame and never logs, so the alternate screen stays the sole owner of
+// the console.
 internal sealed class SpectreTerminalRenderer(IAnsiConsole console) : ITerminalRenderer
 {
     private const string EnterAlternateScreen = "\u001b[?1049h";
     private const string LeaveAlternateScreen = "\u001b[?1049l";
+    private const string BeginSynchronizedUpdate = "\u001b[?2026h";
+    private const string EndSynchronizedUpdate = "\u001b[?2026l";
 
     private int _offset;
 
@@ -30,24 +32,35 @@ internal sealed class SpectreTerminalRenderer(IAnsiConsole console) : ITerminalR
     {
         ArgumentNullException.ThrowIfNull(model);
 
-        console.Clear();
-        if (resizeRequired)
+        var writer = console.Profile.Out.Writer;
+        writer.Write(BeginSynchronizedUpdate);
+        writer.Flush();
+        try
         {
-            _offset = 0;
-            console.Write(ViewportRenderable.RenderResizeRequired(width, height));
-            return;
+            console.Clear();
+            if (resizeRequired)
+            {
+                _offset = 0;
+                console.Write(ViewportRenderable.RenderResizeRequired(width, height));
+                return;
+            }
+
+            var header = TerminalFrame.RenderHeader(model);
+            var footer = TerminalFrame.RenderFooter(model);
+            var (content, contentLines, focusedLine) = BuildContent(model, width);
+
+            var reserved = CountLines(header, width) + CountLines(footer, width);
+            var contentHeight = ViewportState.ContentHeight(height, reserved);
+            var viewport = ViewportState.Calculate(contentLines, contentHeight, focusedLine, _offset);
+            _offset = viewport.Offset;
+
+            console.Write(new Rows(header, new ViewportRenderable(content, viewport), footer));
         }
-
-        var header = TerminalFrame.RenderHeader(model);
-        var footer = TerminalFrame.RenderFooter(model);
-        var (content, contentLines, focusedLine) = BuildContent(model, width);
-
-        var reserved = CountLines(header, width) + CountLines(footer, width);
-        var contentHeight = ViewportState.ContentHeight(height, reserved);
-        var viewport = ViewportState.Calculate(contentLines, contentHeight, focusedLine, _offset);
-        _offset = viewport.Offset;
-
-        console.Write(new Rows(header, new ViewportRenderable(content, viewport), footer));
+        finally
+        {
+            writer.Write(EndSynchronizedUpdate);
+            writer.Flush();
+        }
     }
 
     public void End()

--- a/code/backend/DD.TerminalClient/TerminalApplication.cs
+++ b/code/backend/DD.TerminalClient/TerminalApplication.cs
@@ -277,7 +277,7 @@ internal sealed class TerminalApplication
 
         if (effect.NotSaved > 0)
         {
-            State = State with { IsOffline = true, StatusMessage = "Offline - the save will be retried." };
+            State = State with { IsOffline = true, StatusMessage = "Save will be retried." };
         }
 
         State = _deps.Reducer.Recompute(State);
@@ -378,7 +378,7 @@ internal sealed class TerminalApplication
             return;
         }
 
-        State = State with { IsOffline = true, StatusMessage = "Offline - showing cached tasks." };
+        State = State with { IsOffline = true, StatusMessage = null };
         StartDelayedTick(ReloadRetryDelay, ApplicationEvent.ReloadSnapshotTick);
     }
 
@@ -717,6 +717,7 @@ internal sealed class TerminalApplication
             IsOffline = State.IsOffline,
             Notification = State.StatusMessage ?? State.Notification,
             ProfileName = _deps.ProfileName,
+            ConnectionUrl = _deps.ConnectionUrl,
             Status = BuildStatus(),
         };
     }

--- a/code/backend/DD.TerminalClient/TerminalDependencies.cs
+++ b/code/backend/DD.TerminalClient/TerminalDependencies.cs
@@ -40,6 +40,8 @@ internal sealed record TerminalDependencies
 
     public required string ProfileName { get; init; }
 
+    public string? ConnectionUrl { get; init; }
+
     // Injectable so retry and timer waits are immediate under test; production uses Task.Delay.
     public Func<TimeSpan, CancellationToken, Task> Delay { get; init; } = Task.Delay;
 

--- a/code/backend/DD.Tests.Unit/TerminalClient/OverviewRendererTests.cs
+++ b/code/backend/DD.Tests.Unit/TerminalClient/OverviewRendererTests.cs
@@ -387,6 +387,35 @@ public sealed class OverviewRendererTests
     }
 
     [Fact]
+    public void RenderContent_Help_NonProductionProfileShowsConnectionUrl()
+    {
+        var status = new TerminalStatus { Kind = TerminalStatusKind.Help };
+        var console = Plain(100);
+
+        console.Write(TerminalFrame.RenderContent(
+            Vm(Project(), status: status, connectionUrl: "http://localhost:5000/"),
+            100));
+
+        Assert.Contains("Debug", console.Output, StringComparison.Ordinal);
+        Assert.Contains("Server", console.Output, StringComparison.Ordinal);
+        Assert.Contains("http://localhost:5000/", console.Output, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void RenderContent_Help_ProductionProfileDoesNotShowDebugSection()
+    {
+        var status = new TerminalStatus { Kind = TerminalStatusKind.Help };
+        var console = Plain(100);
+
+        console.Write(TerminalFrame.RenderContent(
+            Vm(Project(), status: status, profileName: "production"),
+            100));
+
+        Assert.DoesNotContain("Debug", console.Output, StringComparison.Ordinal);
+        Assert.DoesNotContain("Server", console.Output, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void RenderHeader_Offline_ShowsOfflineIndicator()
     {
         var console = Plain(80);
@@ -394,6 +423,18 @@ public sealed class OverviewRendererTests
         console.Write(TerminalFrame.RenderHeader(Vm(Project(), offline: true)));
 
         Assert.Contains("offline", console.Output, StringComparison.Ordinal);
+        Assert.Contains("cached tasks", console.Output, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void RenderFooter_Offline_DoesNotRepeatOfflineStatus()
+    {
+        var console = Plain(80);
+
+        console.Write(TerminalFrame.RenderFooter(Vm(Project(), offline: true)));
+
+        Assert.DoesNotContain("offline", console.Output, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("cached tasks", console.Output, StringComparison.OrdinalIgnoreCase);
     }
 
     [Fact]
@@ -440,6 +481,7 @@ public sealed class OverviewRendererTests
         bool offline = false,
         string? notification = null,
         string profileName = "",
+        string? connectionUrl = null,
         bool showCompleted = false)
     {
         return new TerminalViewModel
@@ -451,6 +493,7 @@ public sealed class OverviewRendererTests
             IsOffline = offline,
             Notification = notification,
             ProfileName = profileName,
+            ConnectionUrl = connectionUrl,
             Status = status ?? new TerminalStatus(),
         };
     }

--- a/code/backend/DD.Tests.Unit/TerminalClient/SpectreTerminalRendererTests.cs
+++ b/code/backend/DD.Tests.Unit/TerminalClient/SpectreTerminalRendererTests.cs
@@ -1,0 +1,34 @@
+using DD.TerminalClient;
+using DD.TerminalClient.Details.Ui;
+using DD.TerminalClient.Domain.Application;
+using Spectre.Console.Testing;
+using Xunit;
+
+namespace DD.Tests.Unit.TerminalClient;
+
+public sealed class SpectreTerminalRendererTests
+{
+    [Fact]
+    public void Render_WrapsFrameInSynchronizedUpdate()
+    {
+        var console = new TestConsole().EmitAnsiSequences();
+        console.Profile.Width = 100;
+        console.Profile.Height = 30;
+        var renderer = new SpectreTerminalRenderer(console);
+
+        renderer.Render(
+            new TerminalViewModel
+            {
+                Overview = new ApplicationState().Projection,
+                Today = new DateOnly(2024, 11, 4),
+            },
+            100,
+            30,
+            resizeRequired: false);
+
+        var begin = console.Output.IndexOf("\u001b[?2026h", StringComparison.Ordinal);
+        var end = console.Output.IndexOf("\u001b[?2026l", StringComparison.Ordinal);
+        Assert.True(begin >= 0);
+        Assert.True(end > begin);
+    }
+}


### PR DESCRIPTION
- Render full-screen frames through synchronized terminal updates
- Show offline state once and keep retry messaging concise
- Expose the connected server URL in non-production help