### PR TITLE
[fix] Persist terminal connection and sync statuses

### DIFF
--- a/.github/instructions/custom-rules.instructions.md
+++ b/.github/instructions/custom-rules.instructions.md
@@ -31,6 +31,10 @@ Rules specific to this repository. **If a rule is here — follow it. No excepti
 
 **Wrap every full-screen alternate-buffer redraw in DEC synchronized output (`CSI ? 2026 h` / `CSI ? 2026 l`) and release it in a `finally` block.** Clearing before sequentially writing the header, content, and footer otherwise exposes partial frames as visible flicker during ordinary keyboard navigation.
 
+**Keep terminal connection, snapshot loading, and save synchronization as independent UI states, rendered together at the top of the footer as a compact lowercase yellow status strip.** Use `offline` only from SignalR lifecycle events, `unsynced` only after a save has failed and until all queued local changes settle, and `stale` while snapshot reload is pending; render every active marker together and never replace them with verbose or transient retry messages.
+
+**Store persistent terminal warnings as explicit application state, not `StatusMessage`.** `StatusMessage` is transient and ordinary input replaces it; a snapshot-retry warning must remain rendered across navigation and editing until a successful snapshot clears its dedicated state.
+
 **When copying or re-emitting Spectre `Segment`s (e.g. clipping the terminal viewport), copy a `SegmentLine` with `list.AddRange(segmentLine)` or `foreach`, never the collection-expression spread `[.. segmentLine]`.** The spread injects `null` padding segments into the copy, which later throw `NullReferenceException` deep inside `Spectre.Console.Rendering.Segment.Merge` when the output is written. An empty `[]` is safe; only spreading a non-empty `SegmentLine` is affected.
 
 **Render terminal day cards as one top-to-bottom stream with a blank line between cards, but no trailing blank line after the final card.** Up/Down navigates the immediately previous/next visible task across all sections; Left/Right navigates the previous/next non-empty rendered day and lands on its first task.

--- a/code/backend/DD.TerminalClient.Details/Realtime/TaskHubClient.cs
+++ b/code/backend/DD.TerminalClient.Details/Realtime/TaskHubClient.cs
@@ -112,7 +112,12 @@ internal sealed class TaskHubClient(
         }
         else if (outcome == TaskHubConnectOutcome.Failed)
         {
+            Emit(TaskHubEvent.Reconnecting);
             StartReconnectLoop();
+        }
+        else if (outcome == TaskHubConnectOutcome.Connected)
+        {
+            Emit(TaskHubEvent.Connected);
         }
     }
 

--- a/code/backend/DD.TerminalClient.Details/Ui/TerminalFrame.cs
+++ b/code/backend/DD.TerminalClient.Details/Ui/TerminalFrame.cs
@@ -36,10 +36,6 @@ public static class TerminalFrame
             right.Add("[grey]completed shown[/]");
         }
 
-        right.Add(model.IsOffline
-            ? "[red bold]offline[/] [grey](cached tasks)[/]"
-            : "[green]online[/]");
-
         var grid = new Grid { Expand = true };
         grid.AddColumn(new GridColumn().NoWrap());
         grid.AddColumn(new GridColumn().NoWrap().RightAligned());
@@ -70,6 +66,11 @@ public static class TerminalFrame
         ArgumentNullException.ThrowIfNull(model);
 
         var body = new List<IRenderable>();
+        var persistentStatus = BuildPersistentStatus(model);
+        if (persistentStatus is not null)
+        {
+            body.Add(persistentStatus);
+        }
 
         if (model.Notification is { } notification && !string.IsNullOrWhiteSpace(notification))
         {
@@ -104,6 +105,29 @@ public static class TerminalFrame
             .Expand()
             .Border(BoxBorder.Rounded)
             .BorderColor(Color.Grey);
+    }
+
+    private static Markup? BuildPersistentStatus(TerminalViewModel model)
+    {
+        var statuses = new List<string>();
+        if (model.IsOffline)
+        {
+            statuses.Add("offline");
+        }
+
+        if (model.HasUnsyncedChanges)
+        {
+            statuses.Add("unsynced");
+        }
+
+        if (model.IsSnapshotReloadPending)
+        {
+            statuses.Add("stale");
+        }
+
+        return statuses.Count == 0
+            ? null
+            : new Markup("[yellow]" + string.Join(" ", statuses) + "[/]");
     }
 
     private static Panel RenderHelp(TerminalViewModel model)

--- a/code/backend/DD.TerminalClient.Details/Ui/TerminalViewModel.cs
+++ b/code/backend/DD.TerminalClient.Details/Ui/TerminalViewModel.cs
@@ -19,6 +19,10 @@ public sealed record TerminalViewModel
 
     public bool IsOffline { get; init; }
 
+    public bool HasUnsyncedChanges { get; init; }
+
+    public bool IsSnapshotReloadPending { get; init; }
+
     public string? Notification { get; init; }
 
     public string ProfileName { get; init; } = string.Empty;

--- a/code/backend/DD.TerminalClient.Domain/Application/ApplicationReducer.cs
+++ b/code/backend/DD.TerminalClient.Domain/Application/ApplicationReducer.cs
@@ -256,7 +256,7 @@ public sealed class ApplicationReducer(
             TerminalCommand.ToggleCompletedVisibility => ToggleCompletedVisibility(state),
             TerminalCommand.ToggleRoutine => ToggleRoutine(state),
             TerminalCommand.ForceReconnect => ApplicationTransition.Of(
-                state with { IsBuffering = true, StatusMessage = "Reconnecting..." },
+                state with { IsBuffering = true, IsOffline = true, StatusMessage = null },
                 ApplicationEffect.Reconnect),
             TerminalCommand.Quit => ApplicationTransition.Of(state with { Quit = true }),
             TerminalCommand.SubmitAddWithFocusDate => Create(state, text, fallbackDate),

--- a/code/backend/DD.TerminalClient.Domain/Application/ApplicationState.cs
+++ b/code/backend/DD.TerminalClient.Domain/Application/ApplicationState.cs
@@ -57,7 +57,13 @@ public sealed record ApplicationState
     // True while a snapshot load is in progress and the hub is buffering incoming pushes for replay.
     public bool IsBuffering { get; init; }
 
+    // True after a snapshot transport failure until a later reload succeeds.
+    public bool IsSnapshotReloadPending { get; init; }
+
     public bool IsSaving { get; init; }
+
+    // True after a save transport failure until the queued local changes are accepted by the backend.
+    public bool HasUnsyncedChanges { get; init; }
 
     public TerminalInputState Input { get; init; } = TerminalInputState.Normal;
 

--- a/code/backend/DD.TerminalClient.Domain/Realtime/TaskHubEvent.cs
+++ b/code/backend/DD.TerminalClient.Domain/Realtime/TaskHubEvent.cs
@@ -30,6 +30,8 @@ public sealed record TaskHubEvent
 
     public static TaskHubEvent Heartbeat { get; } = new(TaskHubEventKind.Heartbeat, NoTasks);
 
+    public static TaskHubEvent Connected { get; } = new(TaskHubEventKind.Connected, NoTasks);
+
     public static TaskHubEvent Update(IReadOnlyList<TerminalTask> tasks)
     {
         ArgumentNullException.ThrowIfNull(tasks);

--- a/code/backend/DD.TerminalClient.Domain/Realtime/TaskHubEventKind.cs
+++ b/code/backend/DD.TerminalClient.Domain/Realtime/TaskHubEventKind.cs
@@ -7,6 +7,7 @@ public enum TaskHubEventKind
 {
     Update,
     Heartbeat,
+    Connected,
     Reconnecting,
     Reconnected,
     Closed,

--- a/code/backend/DD.TerminalClient/TerminalApplication.cs
+++ b/code/backend/DD.TerminalClient/TerminalApplication.cs
@@ -252,7 +252,11 @@ internal sealed class TerminalApplication
                     StartDelayedTick(effect.RetryDelay, ApplicationEvent.RetryTick);
                     break;
                 case TaskSyncEffectKind.ReportSyncStatus:
-                    State = State with { IsSaving = effect.IsSaving };
+                    State = State with
+                    {
+                        IsSaving = effect.IsSaving,
+                        HasUnsyncedChanges = effect.IsSaving && State.HasUnsyncedChanges,
+                    };
                     break;
                 case TaskSyncEffectKind.SaveFinished:
                     ApplySaveFinished(effect);
@@ -277,7 +281,7 @@ internal sealed class TerminalApplication
 
         if (effect.NotSaved > 0)
         {
-            State = State with { IsOffline = true, StatusMessage = "Save will be retried." };
+            State = State with { HasUnsyncedChanges = true };
         }
 
         State = _deps.Reducer.Recompute(State);
@@ -300,8 +304,11 @@ internal sealed class TerminalApplication
 
                 State = State with { IsOffline = false };
                 break;
+            case TaskHubEventKind.Connected:
+                State = State with { IsOffline = false };
+                break;
             case TaskHubEventKind.Reconnecting:
-                State = State with { IsOffline = true, IsBuffering = true, StatusMessage = "Reconnecting..." };
+                State = State with { IsOffline = true, IsBuffering = true, StatusMessage = null };
                 break;
             case TaskHubEventKind.Reconnected:
                 State = State with { IsBuffering = true, IsOffline = false };
@@ -342,7 +349,12 @@ internal sealed class TerminalApplication
             DrainRestoredOutbox();
         }
 
-        State = _deps.Reducer.Recompute(State with { IsBuffering = false, IsOffline = false });
+        State = _deps.Reducer.Recompute(State with
+        {
+            IsBuffering = false,
+            IsSnapshotReloadPending = false,
+            StatusMessage = null,
+        });
         PersistState();
     }
 
@@ -378,7 +390,7 @@ internal sealed class TerminalApplication
             return;
         }
 
-        State = State with { IsOffline = true, StatusMessage = null };
+        State = State with { IsSnapshotReloadPending = true };
         StartDelayedTick(ReloadRetryDelay, ApplicationEvent.ReloadSnapshotTick);
     }
 
@@ -403,7 +415,6 @@ internal sealed class TerminalApplication
 
     private void HandleSaveCompleted(IReadOnlyList<TerminalTask> saved)
     {
-        State = State with { IsOffline = false };
         RunSyncEffects(_sync.OnSaveSucceeded(saved));
     }
 
@@ -415,7 +426,6 @@ internal sealed class TerminalApplication
             return;
         }
 
-        State = State with { IsOffline = true };
         RunSyncEffects(_sync.OnSaveFailed());
     }
 
@@ -557,6 +567,8 @@ internal sealed class TerminalApplication
             Phase = ApplicationPhase.Ready,
             Input = TerminalInputState.Normal,
             SuspendedInput = null,
+            HasUnsyncedChanges = false,
+            IsSnapshotReloadPending = false,
             ConfirmUser = null,
             ConfirmOwner = null,
             StatusMessage = null,
@@ -620,7 +632,9 @@ internal sealed class TerminalApplication
             Input = TerminalInputState.BeginLogin(),
             IsOffline = false,
             IsBuffering = false,
+            IsSnapshotReloadPending = false,
             IsSaving = false,
+            HasUnsyncedChanges = false,
             StatusMessage = "Session expired. Please sign in again.",
         };
     }
@@ -632,7 +646,7 @@ internal sealed class TerminalApplication
         _sessionCts?.Cancel();
         _sessionCts?.Dispose();
         _sessionCts = CancellationTokenSource.CreateLinkedTokenSource(_appToken);
-        State = State with { IsBuffering = true, IsOffline = false };
+        State = State with { IsBuffering = true, IsOffline = true };
         _ = StartHubAndLoadAsync(++_snapshotGeneration);
     }
 
@@ -715,6 +729,8 @@ internal sealed class TerminalApplication
             Today = _deps.LocalDate.Today,
             ShowCompleted = State.ShowCompleted,
             IsOffline = State.IsOffline,
+            HasUnsyncedChanges = State.HasUnsyncedChanges,
+            IsSnapshotReloadPending = State.IsSnapshotReloadPending,
             Notification = State.StatusMessage ?? State.Notification,
             ProfileName = _deps.ProfileName,
             ConnectionUrl = _deps.ConnectionUrl,

--- a/code/backend/DD.Tests.Unit/TerminalClient/OverviewRendererTests.cs
+++ b/code/backend/DD.Tests.Unit/TerminalClient/OverviewRendererTests.cs
@@ -416,25 +416,66 @@ public sealed class OverviewRendererTests
     }
 
     [Fact]
-    public void RenderHeader_Offline_ShowsOfflineIndicator()
-    {
-        var console = Plain(80);
-
-        console.Write(TerminalFrame.RenderHeader(Vm(Project(), offline: true)));
-
-        Assert.Contains("offline", console.Output, StringComparison.Ordinal);
-        Assert.Contains("cached tasks", console.Output, StringComparison.Ordinal);
-    }
-
-    [Fact]
-    public void RenderFooter_Offline_DoesNotRepeatOfflineStatus()
+    public void RenderFooter_Offline_ShowsPersistentStatus()
     {
         var console = Plain(80);
 
         console.Write(TerminalFrame.RenderFooter(Vm(Project(), offline: true)));
 
+        Assert.Contains("offline", console.Output, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void RenderFooter_Unsynced_ShowsIndependentStatus()
+    {
+        var console = Plain(80);
+
+        console.Write(TerminalFrame.RenderFooter(Vm(Project(), hasUnsyncedChanges: true)));
+
+        Assert.Contains("unsynced", console.Output, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void RenderFooter_MultipleProblems_ShowsCompactYellowStatusStrip()
+    {
+        var footer = TerminalFrame.RenderFooter(Vm(
+            Project(),
+            offline: true,
+            hasUnsyncedChanges: true,
+            snapshotReloadPending: true));
+        var console = Plain(80);
+        console.Write(footer);
+        var ansi = Ansi(footer, 80);
+
+        Assert.Contains("offline unsynced stale", console.Output, StringComparison.Ordinal);
+        Assert.Contains("[38;5;11m", ansi, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void RenderHeader_DoesNotRenderConnectionOrSyncStatus()
+    {
+        var console = Plain(80);
+
+        console.Write(TerminalFrame.RenderHeader(Vm(
+            Project(),
+            offline: true,
+            hasUnsyncedChanges: true,
+            snapshotReloadPending: true)));
+
         Assert.DoesNotContain("offline", console.Output, StringComparison.OrdinalIgnoreCase);
-        Assert.DoesNotContain("cached tasks", console.Output, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("unsynced", console.Output, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("stale", console.Output, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void RenderFooter_SnapshotReloadPending_ShowsOnlyStaleStatus()
+    {
+        var console = Plain(80);
+
+        console.Write(TerminalFrame.RenderFooter(Vm(Project(), snapshotReloadPending: true)));
+
+        Assert.Contains("stale", console.Output, StringComparison.Ordinal);
+        Assert.DoesNotContain("retried", console.Output, StringComparison.OrdinalIgnoreCase);
     }
 
     [Fact]
@@ -482,6 +523,8 @@ public sealed class OverviewRendererTests
         string? notification = null,
         string profileName = "",
         string? connectionUrl = null,
+        bool hasUnsyncedChanges = false,
+        bool snapshotReloadPending = false,
         bool showCompleted = false)
     {
         return new TerminalViewModel
@@ -491,6 +534,8 @@ public sealed class OverviewRendererTests
             Today = Monday,
             ShowCompleted = showCompleted,
             IsOffline = offline,
+            HasUnsyncedChanges = hasUnsyncedChanges,
+            IsSnapshotReloadPending = snapshotReloadPending,
             Notification = notification,
             ProfileName = profileName,
             ConnectionUrl = connectionUrl,

--- a/code/backend/DD.Tests.Unit/TerminalClient/TaskHubClientTests.cs
+++ b/code/backend/DD.Tests.Unit/TerminalClient/TaskHubClientTests.cs
@@ -55,7 +55,7 @@ public sealed class TaskHubClientTests
     }
 
     [Fact]
-    public async Task StartAsync_FirstConnectSucceeds_ReadsTokenAndEmitsNoEvent()
+    public async Task StartAsync_FirstConnectSucceeds_ReadsTokenAndEmitsConnected()
     {
         var collector = new EventCollector();
         var factory = new FakeHubConnectionFactory();
@@ -67,8 +67,7 @@ public sealed class TaskHubClientTests
         Assert.Equal(1, factory.Connection.StartCount);
         Assert.Equal("jwt-1", Assert.Single(factory.Connection.TokensSeen));
 
-        // The first connect is silent - startup loads the initial snapshot itself - so no reconnect fires.
-        Assert.Empty(collector.Snapshot());
+        Assert.Equal(TaskHubEventKind.Connected, Assert.Single(collector.Kinds()));
     }
 
     [Fact]
@@ -116,8 +115,7 @@ public sealed class TaskHubClientTests
         Assert.Equal(2, factory.Connection.StartCount);
         Assert.Equal(TimeSpan.FromSeconds(1), delay.Snapshot()[0]);
 
-        // An offline start emits no Reconnecting (nothing was ever connected to lose).
-        Assert.DoesNotContain(TaskHubEventKind.Reconnecting, collector.Kinds());
+        Assert.Contains(TaskHubEventKind.Reconnecting, collector.Kinds());
     }
 
     [Fact]

--- a/code/backend/DD.Tests.Unit/TerminalClient/TerminalApplicationTests.cs
+++ b/code/backend/DD.Tests.Unit/TerminalClient/TerminalApplicationTests.cs
@@ -12,6 +12,8 @@ using DD.TerminalClient.Domain.Overview;
 using DD.TerminalClient.Domain.Realtime;
 using DD.TerminalClient.Domain.State;
 using DD.TerminalClient.Domain.Time;
+using Spectre.Console;
+using Spectre.Console.Testing;
 using Xunit;
 
 namespace DD.Tests.Unit.TerminalClient;
@@ -42,7 +44,7 @@ public sealed class TerminalApplicationTests
     }
 
     [Fact]
-    public async Task Startup_LoadFails_ShowsCachedTasksOffline()
+    public async Task Startup_LoadFails_ShowsCachedTasksWithoutChangingConnectionStatus()
     {
         using var harness = new Harness();
         harness.TokenStore.Save(Jwt("alice", Now.AddDays(30)));
@@ -54,9 +56,56 @@ public sealed class TerminalApplicationTests
         harness.Tasks.LoadHandler = () => throw new TerminalApiException(TerminalApiErrorKind.Transport, "down");
 
         var run = harness.Start();
-        await WaitForAsync(() => harness.LastModel().IsOffline, "offline indicator");
+        await WaitForAsync(
+            () => harness.LastModel().IsSnapshotReloadPending,
+            "snapshot retry notice");
 
         Assert.True(HasTask(harness.LastModel(), "cached"));
+        Assert.False(harness.LastModel().IsOffline);
+
+        harness.Enqueue(Key('?'));
+        await WaitForAsync(
+            () => harness.LastModel().Status.Kind == TerminalStatusKind.Help
+                && harness.LastModel().IsSnapshotReloadPending,
+            "snapshot retry notice after navigation");
+        await harness.StopAsync(run);
+    }
+
+    [Fact]
+    public async Task Startup_HubDisconnected_ShowsOfflineEvenWhenSnapshotLoads()
+    {
+        using var harness = new Harness();
+        harness.TokenStore.Save(Jwt("alice", Now.AddDays(30)));
+        harness.StateStore.Set(new PersistedTerminalState { DataOwner = "alice" });
+        harness.Hub.StartEvent = TaskHubEvent.Reconnecting;
+        harness.Tasks.LoadResult = [Task("server", "Server task")];
+
+        var run = harness.Start();
+        await WaitForAsync(() => HasTask(harness.LastModel(), "server"), "snapshot loaded");
+
+        Assert.True(harness.LastModel().IsOffline);
+        await harness.StopAsync(run);
+    }
+
+    [Fact]
+    public async Task HubReconnecting_OfflinePersistsAcrossInputWithoutTransientMessage()
+    {
+        using var harness = new Harness();
+        harness.TokenStore.Save(Jwt("alice", Now.AddDays(30)));
+        harness.StateStore.Set(new PersistedTerminalState { DataOwner = "alice" });
+
+        var run = harness.Start();
+        await WaitForAsync(() => !harness.LastModel().IsOffline, "initial connection");
+
+        harness.Hub.Raise(TaskHubEvent.Reconnecting);
+        await WaitForAsync(() => harness.LastModel().IsOffline, "offline after connection loss");
+        Assert.Null(harness.LastModel().Notification);
+
+        harness.Enqueue(Key('?'));
+        await WaitForAsync(() => harness.LastModel().Status.Kind == TerminalStatusKind.Help, "help opened");
+        Assert.True(harness.LastModel().IsOffline);
+        Assert.Null(harness.LastModel().Notification);
+
         await harness.StopAsync(run);
     }
 
@@ -319,9 +368,9 @@ public sealed class TerminalApplicationTests
     }
 
     [Fact]
-    public async Task Save_TransportError_SchedulesRetryThenSucceeds()
+    public async Task Save_TransportError_ShowsUnsyncedUntilRetrySucceeds()
     {
-        using var harness = new Harness(immediateDelay: true);
+        using var harness = new Harness();
         harness.TokenStore.Save(Jwt("alice", Now.AddDays(30)));
         harness.StateStore.Set(new PersistedTerminalState
         {
@@ -342,8 +391,48 @@ public sealed class TerminalApplicationTests
         await WaitForAsync(() => HasTask(harness.LastModel(), "a"), "task rendered");
 
         harness.Enqueue(Space());
-        await WaitForAsync(() => harness.Tasks.SavedBatches.Count >= 2, "save retried");
+        await WaitForAsync(() => harness.LastModel().HasUnsyncedChanges, "unsynced marker");
 
+        Assert.False(harness.LastModel().IsOffline);
+        Assert.Null(harness.LastModel().Notification);
+
+        harness.Hub.Raise(TaskHubEvent.Reconnecting);
+        await WaitForAsync(
+            () => harness.LastModel().IsOffline && harness.LastModel().HasUnsyncedChanges,
+            "combined offline and unsynced state");
+        Assert.Contains("offline unsynced", RenderFooter(harness.LastModel()), StringComparison.Ordinal);
+
+        harness.Enqueue(Key('?'));
+        await WaitForAsync(() => harness.LastModel().Status.Kind == TerminalStatusKind.Help, "help opened");
+        Assert.Contains("offline unsynced", RenderFooter(harness.LastModel()), StringComparison.Ordinal);
+
+        harness.Enqueue(ApplicationEvent.RetryTick);
+        await WaitForAsync(() => harness.Tasks.SavedBatches.Count >= 2, "save retried");
+        await WaitForAsync(() => !harness.LastModel().HasUnsyncedChanges, "unsynced marker cleared");
+
+        await harness.StopAsync(run);
+    }
+
+    [Fact]
+    public async Task Save_FirstAttemptInFlight_DoesNotShowUnsynced()
+    {
+        using var harness = new Harness();
+        harness.TokenStore.Save(Jwt("alice", Now.AddDays(30)));
+        harness.StateStore.Set(new PersistedTerminalState
+        {
+            DataOwner = "alice",
+            CachedTasks = [Task("a", "Task A")],
+        });
+        harness.Tasks.LoadResult = [Task("a", "Task A")];
+        harness.Tasks.HoldSaves();
+
+        var run = harness.Start();
+        await WaitForAsync(() => HasTask(harness.LastModel(), "a"), "task rendered");
+
+        harness.Enqueue(Space());
+        await WaitForAsync(() => harness.Tasks.SavedBatches.Count >= 1, "first save in flight");
+
+        Assert.False(harness.LastModel().HasUnsyncedChanges);
         await harness.StopAsync(run);
     }
 
@@ -703,11 +792,16 @@ public sealed class TerminalApplicationTests
         };
 
         var run = harness.Start();
-        await WaitForAsync(() => harness.LastModel().IsOffline, "offline after failed snapshot");
+        await WaitForAsync(
+            () => harness.LastModel().IsSnapshotReloadPending,
+            "snapshot retry notice");
 
         harness.Hub.Raise(TaskHubEvent.Heartbeat);
         harness.Enqueue(ApplicationEvent.ReloadSnapshotTick);
         await WaitForAsync(() => harness.Tasks.LoadCount >= 2, "snapshot reloaded despite heartbeat");
+        await WaitForAsync(
+            () => !harness.LastModel().IsSnapshotReloadPending,
+            "snapshot retry notice cleared");
 
         await harness.StopAsync(run);
     }
@@ -724,6 +818,15 @@ public sealed class TerminalApplicationTests
 
             await System.Threading.Tasks.Task.Delay(10);
         }
+    }
+
+    private static string RenderFooter(TerminalViewModel model)
+    {
+        var console = new TestConsole();
+        console.Profile.Width = 140;
+        console.Profile.Height = 40;
+        console.Write(TerminalFrame.RenderFooter(model));
+        return console.Output;
     }
 
     private static bool HasTask(TerminalViewModel model, string uid)
@@ -1052,6 +1155,8 @@ public sealed class TerminalApplicationTests
 
         public bool ThrowOnDispose { get; set; }
 
+        public TaskHubEvent StartEvent { get; set; } = TaskHubEvent.Connected;
+
         public Task StartAsync(CancellationToken cancellationToken)
         {
             lock (_gate)
@@ -1059,6 +1164,7 @@ public sealed class TerminalApplicationTests
                 StartCount++;
             }
 
+            Sink?.Invoke(StartEvent);
             return System.Threading.Tasks.Task.CompletedTask;
         }
 


### PR DESCRIPTION
- Render offline, unsynced, and stale together in the footer
- Keep connection and save-failure state across ordinary input
- Show unsynced only after a failed save until the outbox settles
- Remove transient reconnect and retry messages