### PR TITLE
[feat] Improve terminal overview layout

### DIFF
--- a/.github/instructions/custom-rules.instructions.md
+++ b/.github/instructions/custom-rules.instructions.md
@@ -31,7 +31,13 @@ Rules specific to this repository. **If a rule is here — follow it. No excepti
 
 **Wrap every full-screen alternate-buffer redraw in DEC synchronized output (`CSI ? 2026 h` / `CSI ? 2026 l`) and release it in a `finally` block.** Clearing before sequentially writing the header, content, and footer otherwise exposes partial frames as visible flicker during ordinary keyboard navigation.
 
-**Keep terminal connection, snapshot loading, and save synchronization as independent UI states, rendered together at the top of the footer as a compact lowercase yellow status strip.** Use `offline` only from SignalR lifecycle events, `unsynced` only after a save has failed and until all queued local changes settle, and `stale` while snapshot reload is pending; render every active marker together and never replace them with verbose or transient retry messages.
+**Leave the final terminal column unused and omit the frame's trailing line break when rendering a full-screen alternate-buffer frame.** Filling the bottom-right cell or advancing past a footer drawn on the final row can make native terminals scroll the buffer and hide the fixed header, even when IDE consoles render the same frame correctly; this avoids the scroll without wasting vertical space.
+
+**Keep terminal connection, snapshot loading, and save synchronization as independent UI states, rendered together at the right of the fixed header as a compact lowercase yellow status strip.** Use `offline` only from SignalR lifecycle events, `unsynced` only after a save has failed and until all queued local changes settle, and `stale` while snapshot reload is pending; render every active marker together, keep them out of the footer, and never replace them with verbose or transient retry messages.
+
+**Show the active terminal profile beside `Dark Deeds` only when it is not `production`, and never repeat profile or backend details inside Help.** The fixed header is the single location for environment identity.
+
+**Do not render a `completed shown` indicator in the terminal header.** Completed-task visibility remains a view mode controlled by `c`, not a persistent status.
 
 **Store persistent terminal warnings as explicit application state, not `StatusMessage`.** `StatusMessage` is transient and ordinary input replaces it; a snapshot-retry warning must remain rendered across navigation and editing until a successful snapshot clears its dedicated state.
 
@@ -39,7 +45,9 @@ Rules specific to this repository. **If a rule is here — follow it. No excepti
 
 **Render terminal day cards as one top-to-bottom stream with a blank line between cards, but no trailing blank line after the final card.** Up/Down navigates the immediately previous/next visible task across all sections; Left/Right navigates the previous/next non-empty rendered day and lands on its first task.
 
-**For a collapsed dated Routine group, always render the summary when at least one nondeleted Routine task exists, and count only incomplete Routine tasks.** Therefore a day whose Routine tasks are all completed renders `+0 routine`; expanded Routine groups and No Date tasks do not render this summary.
+**Always render all fourteen Current day cards, including days with no visible tasks, and visually separate the two weeks.** Replace the ordinary blank card separator between the first Sunday and second Monday with one short dim-grey line; do not add an extra row.
+
+**For a collapsed dated Routine group, render the summary when at least one Routine task is visible under the completed-task filter, and count only incomplete Routine tasks.** Therefore a day whose Routine tasks are all completed renders `+0 routine` only while completed tasks are shown; expanded Routine groups and No Date tasks do not render this summary.
 
 **The terminal `r` shortcut globally toggles dated Routine visibility for every day and does not require a focused task.** Keep this as a boolean view mode so Routine tasks added or received on new dates while expanded are shown automatically; pressing `r` again collapses every dated Routine group.
 

--- a/code/backend/DD.TerminalClient.Details/Ui/OverviewRenderer.cs
+++ b/code/backend/DD.TerminalClient.Details/Ui/OverviewRenderer.cs
@@ -9,9 +9,10 @@ namespace DD.TerminalClient.Details.Ui;
 // Renders the Overview projection into a flat, top-to-bottom list of single-line renderables plus the
 // per-task line metadata the viewport consumes. Every visible task becomes exactly one ellipsized line,
 // so its VisualTaskAddress maps deterministically to a content line index regardless of title length.
-// Section titles, day headers and the collapsed-Routine summary each also occupy exactly one line. User
-// titles are sanitized, cell-width truncated and rendered as plain styled Text, never parsed as markup,
-// so a title containing "[" or Spectre tags can neither break the layout nor inject styling.
+// Section titles, day headers, the current-week separator and the collapsed-Routine summary each also
+// occupy exactly one line. User titles are sanitized, cell-width truncated and rendered as plain styled
+// Text, never parsed as markup, so a title containing "[" or Spectre tags can neither break the layout
+// nor inject styling.
 public static class OverviewRenderer
 {
     private const string AdditionalIndent = "            ";
@@ -28,7 +29,7 @@ public static class OverviewRenderer
 
         AppendNoDate(lines, taskLines, overview.NoDate, focusUid, width);
         AppendDatedSection(lines, taskLines, "Expired", overview.Overdue, model.Today, focusUid, width);
-        AppendDatedSection(lines, taskLines, "Current", overview.Current, model.Today, focusUid, width);
+        AppendCurrentSection(lines, taskLines, overview.Current, model.Today, focusUid, width);
         AppendDatedSection(lines, taskLines, "Future", overview.Future, model.Today, focusUid, width);
 
         return new RenderedOverview { Lines = lines, TaskLines = taskLines };
@@ -39,6 +40,29 @@ public static class OverviewRenderer
         var marker = isSelected ? "> " : "  ";
         var typeIndent = task.Type == TerminalTaskType.Additional ? AdditionalIndent : string.Empty;
         return marker + typeIndent;
+    }
+
+    private static void AppendCurrentSection(
+        List<IRenderable> lines,
+        List<TaskLine> taskLines,
+        IReadOnlyList<OverviewDay> days,
+        DateOnly today,
+        string? focusUid,
+        int width)
+    {
+        AppendCardSeparator(lines);
+        lines.Add(SectionTitleLine("Current", width));
+        for (var i = 0; i < days.Count; i++)
+        {
+            if (i > 0)
+            {
+                lines.Add(i == 7 ? WeekSeparatorLine(width) : new Text(string.Empty));
+            }
+
+            var day = days[i];
+            lines.Add(DayHeaderLine(day, today, width));
+            AppendTasks(lines, taskLines, day, focusUid, width);
+        }
     }
 
     private static void AppendNoDate(
@@ -146,6 +170,12 @@ public static class OverviewRenderer
         var label = "    +" + count.ToString(CultureInfo.InvariantCulture) + " routine";
         var style = count == 0 ? TerminalStyles.CompletedHint : TerminalStyles.Hint;
         return new Text(TerminalText.Truncate(label, width), style);
+    }
+
+    private static Text WeekSeparatorLine(int width)
+    {
+        var separatorWidth = Math.Min(24, Math.Max(0, width - 2));
+        return new Text("  " + new string('-', separatorWidth), TerminalStyles.WeekSeparator);
     }
 
     private static void AppendCardSeparator(List<IRenderable> lines)

--- a/code/backend/DD.TerminalClient.Details/Ui/RenderedOverview.cs
+++ b/code/backend/DD.TerminalClient.Details/Ui/RenderedOverview.cs
@@ -4,9 +4,9 @@ namespace DD.TerminalClient.Details.Ui;
 
 // The Overview content rendered as a flat, top-to-bottom list of single-line renderables plus the line
 // metadata for every visible task. Lines contains one renderable per visual line (section titles, day
-// headers, task lines and the collapsed-Routine summary), each exactly one terminal line tall, so
-// TaskLines[i].LineIndex indexes directly into Lines. The viewport clips Lines and reserves the fixed
-// header and footer around them.
+// headers, week separators, task lines and the collapsed-Routine summary), each exactly one terminal
+// line tall, so TaskLines[i].LineIndex indexes directly into Lines. The viewport clips Lines and reserves
+// the fixed header and footer around them.
 public sealed record RenderedOverview
 {
     public IReadOnlyList<IRenderable> Lines { get; init; } = [];

--- a/code/backend/DD.TerminalClient.Details/Ui/TerminalFrame.cs
+++ b/code/backend/DD.TerminalClient.Details/Ui/TerminalFrame.cs
@@ -7,11 +7,12 @@ using Spectre.Console.Rendering;
 namespace DD.TerminalClient.Details.Ui;
 
 // Assembles the full terminal frame: a fixed one-line header, the scrollable Overview (or the help
-// keymap, or an empty-state message), and a fixed status footer. The footer reflects the current mode
+// keymap, or an empty-state message), and a fixed action footer. The header carries persistent connection
+// and synchronization statuses; the footer reflects the current mode
 // without ever running a Spectre prompt inside the live display: it draws the supplied editor/login
 // buffer and cursor as ordinary styled text, shows the delete confirmation question, the full focused
 // task text in Normal mode, and conflict/action notifications. All user-supplied text (titles, profile
-// name, connection URL, notifications, editor buffer) is escaped so it can never be interpreted as markup.
+// name, notifications, editor buffer) is escaped so it can never be interpreted as markup.
 public static class TerminalFrame
 {
     public static IRenderable Render(TerminalViewModel model, int width)
@@ -25,15 +26,16 @@ public static class TerminalFrame
         ArgumentNullException.ThrowIfNull(model);
 
         var left = "[bold]Dark Deeds[/]";
-        if (!string.IsNullOrEmpty(model.ProfileName))
+        if (!string.IsNullOrEmpty(model.ProfileName)
+            && !string.Equals(model.ProfileName, "production", StringComparison.OrdinalIgnoreCase))
         {
             left += " [grey]" + Markup.Escape(model.ProfileName) + "[/]";
         }
 
         var right = new List<string>();
-        if (model.ShowCompleted)
+        if (BuildPersistentStatus(model) is { } persistentStatus)
         {
-            right.Add("[grey]completed shown[/]");
+            right.Add("[yellow]" + persistentStatus + "[/]");
         }
 
         var grid = new Grid { Expand = true };
@@ -49,7 +51,7 @@ public static class TerminalFrame
 
         if (model.Status.Kind == TerminalStatusKind.Help)
         {
-            return RenderHelp(model);
+            return RenderHelp();
         }
 
         var overview = OverviewRenderer.Render(model, width);
@@ -66,12 +68,6 @@ public static class TerminalFrame
         ArgumentNullException.ThrowIfNull(model);
 
         var body = new List<IRenderable>();
-        var persistentStatus = BuildPersistentStatus(model);
-        if (persistentStatus is not null)
-        {
-            body.Add(persistentStatus);
-        }
-
         if (model.Notification is { } notification && !string.IsNullOrWhiteSpace(notification))
         {
             body.Add(new Markup("[yellow bold]" + Markup.Escape(TerminalText.Sanitize(notification)) + "[/]"));
@@ -107,7 +103,7 @@ public static class TerminalFrame
             .BorderColor(Color.Grey);
     }
 
-    private static Markup? BuildPersistentStatus(TerminalViewModel model)
+    private static string? BuildPersistentStatus(TerminalViewModel model)
     {
         var statuses = new List<string>();
         if (model.IsOffline)
@@ -125,12 +121,10 @@ public static class TerminalFrame
             statuses.Add("stale");
         }
 
-        return statuses.Count == 0
-            ? null
-            : new Markup("[yellow]" + string.Join(" ", statuses) + "[/]");
+        return statuses.Count == 0 ? null : string.Join(" ", statuses);
     }
 
-    private static Panel RenderHelp(TerminalViewModel model)
+    private static Panel RenderHelp()
     {
         var grid = new Grid();
         grid.AddColumn(new GridColumn().NoWrap().PadRight(3));
@@ -150,13 +144,6 @@ public static class TerminalFrame
         AddHelpRow(grid, "Ctrl+R", "Reconnect and reload");
         AddHelpRow(grid, "?", "Toggle this help");
         AddHelpRow(grid, "q", "Quit");
-
-        if (!string.IsNullOrWhiteSpace(model.ConnectionUrl))
-        {
-            grid.AddEmptyRow();
-            grid.AddRow(new Markup("[bold]Debug[/]"), new Text(string.Empty));
-            AddHelpRow(grid, "Server", model.ConnectionUrl);
-        }
 
         return new Panel(grid)
             .Header(" Keyboard shortcuts ")

--- a/code/backend/DD.TerminalClient.Details/Ui/TerminalStyles.cs
+++ b/code/backend/DD.TerminalClient.Details/Ui/TerminalStyles.cs
@@ -19,6 +19,8 @@ internal static class TerminalStyles
 
     public static readonly Style CompletedHint = new(Color.Grey, decoration: Decoration.Dim);
 
+    public static readonly Style WeekSeparator = new(Color.Grey, decoration: Decoration.Dim);
+
     public static readonly Style EmptyState = new(Color.Grey, decoration: Decoration.Italic);
 
     // Composes the style for one rendered task line from its type, completion, probability and focus.

--- a/code/backend/DD.TerminalClient.Details/Ui/TerminalViewModel.cs
+++ b/code/backend/DD.TerminalClient.Details/Ui/TerminalViewModel.cs
@@ -4,9 +4,10 @@ using DD.TerminalClient.Domain.Overview;
 namespace DD.TerminalClient.Details.Ui;
 
 // The complete immutable input to the terminal frame renderer: the projected Overview, the current
-// focus, the local date used to highlight today, the local completed-visibility toggle, the connection
-// and conflict indicators, the active profile name and the status area to draw. The event loop maps its
-// application state onto this value once per drained batch; the renderer reads it and produces the frame.
+// focus, the local date used to highlight today, the local completed-visibility toggle, persistent
+// connection and synchronization indicators, the active profile name and the status area to draw. The
+// event loop maps its application state onto this value once per drained batch; the renderer reads it
+// and produces the frame.
 public sealed record TerminalViewModel
 {
     public required OverviewProjection Overview { get; init; }
@@ -26,8 +27,6 @@ public sealed record TerminalViewModel
     public string? Notification { get; init; }
 
     public string ProfileName { get; init; } = string.Empty;
-
-    public string? ConnectionUrl { get; init; }
 
     public TerminalStatus Status { get; init; } = new();
 }

--- a/code/backend/DD.TerminalClient.Domain/Overview/OverviewDay.cs
+++ b/code/backend/DD.TerminalClient.Domain/Overview/OverviewDay.cs
@@ -3,9 +3,9 @@ namespace DD.TerminalClient.Domain.Overview;
 // One day cell in the grid. Date is null only for the single No Date cell. Tasks are already filtered
 // (deleted removed, completed optionally removed), Routine-collapsed for a dated cell whose date is not
 // in the shown set, and sorted by Order. HasCollapsedRoutineTasks records whether the collapsed dated
-// cell has any nondeleted Routine tasks, while CollapsedRoutineCount counts only the incomplete ones.
-// Both stay false/0 for No Date, where Routine is never collapsed. A cell with no visible task is Empty:
-// Current keeps its empty cells for layout while navigation skips them.
+// cell has any Routine tasks visible under the completed filter, while CollapsedRoutineCount counts only
+// the incomplete ones. Both stay false/0 for No Date, where Routine is never collapsed. A cell with no
+// visible task is Empty: Current keeps its empty cells for layout while navigation skips them.
 public sealed record OverviewDay
 {
     public required OverviewSection Section { get; init; }

--- a/code/backend/DD.TerminalClient.Domain/Overview/OverviewProjectionService.cs
+++ b/code/backend/DD.TerminalClient.Domain/Overview/OverviewProjectionService.cs
@@ -37,10 +37,7 @@ public sealed class OverviewProjectionService(ILocalDateProvider localDateProvid
             if (task.Deleted)
                 continue;
 
-            var preservesCollapsedRoutineSummary = task.Type == TerminalTaskType.Routine
-                && task.Date is { } routineDate
-                && !routineShownDates.Contains(routineDate);
-            if (!showCompleted && task.Completed && !preservesCollapsedRoutineSummary)
+            if (!showCompleted && task.Completed)
                 continue;
 
             if (task.Date is not { } date)
@@ -124,9 +121,9 @@ public sealed class OverviewProjectionService(ILocalDateProvider localDateProvid
     }
 
     // Filters and orders one cell's tasks: sort by Order (stable), collapse Routine tasks on a dated cell
-    // whose date is not shown, record whether any exist while counting only incomplete ones, and stamp each
-    // surviving task with its address. TaskIndex counts only visible tasks, so a collapsed Routine leaves
-    // no gap.
+    // whose date is not shown, record whether any visible under the completed filter exist while counting
+    // only incomplete ones, and stamp each surviving task with its address. TaskIndex counts only visible
+    // tasks, so a collapsed Routine leaves no gap.
     private static OverviewDay BuildCell(
         OverviewSection section,
         int row,

--- a/code/backend/DD.TerminalClient/Program.cs
+++ b/code/backend/DD.TerminalClient/Program.cs
@@ -141,9 +141,6 @@ internal static class Program
             SetToken = SetToken,
             ReadDimensions = () => ViewportRenderable.ResolveDimensions(console, ViewportRenderable.ReadWindowSize),
             ProfileName = profile.Name,
-            ConnectionUrl = string.Equals(profile.Name, "production", StringComparison.OrdinalIgnoreCase)
-                ? null
-                : profile.BaseUri.AbsoluteUri,
         };
 
         using var cts = new CancellationTokenSource();

--- a/code/backend/DD.TerminalClient/SpectreTerminalRenderer.cs
+++ b/code/backend/DD.TerminalClient/SpectreTerminalRenderer.cs
@@ -8,9 +8,10 @@ namespace DD.TerminalClient;
 // The production terminal surface: an alternate-screen, full-frame renderer driven by the event loop.
 // Begin switches to the alternate buffer and hides the cursor; End restores both. Each Render replaces
 // the buffer inside a synchronized terminal update, so clearing and writing the header, viewport and
-// footer become visible as one frame instead of flickering through partial output. It never runs a
-// Spectre prompt inside the live frame and never logs, so the alternate screen stays the sole owner of
-// the console.
+// footer become visible as one frame instead of flickering through partial output. The frame leaves the
+// final terminal column unused and omits its trailing line break so writing the footer on the last row
+// cannot scroll a native terminal. It never runs a Spectre prompt inside the live frame and never logs,
+// so the alternate screen stays the sole owner of the console.
 internal sealed class SpectreTerminalRenderer(IAnsiConsole console) : ITerminalRenderer
 {
     private const string EnterAlternateScreen = "\u001b[?1049h";
@@ -45,16 +46,18 @@ internal sealed class SpectreTerminalRenderer(IAnsiConsole console) : ITerminalR
                 return;
             }
 
+            var renderWidth = Math.Max(1, width - 1);
             var header = TerminalFrame.RenderHeader(model);
             var footer = TerminalFrame.RenderFooter(model);
-            var (content, contentLines, focusedLine) = BuildContent(model, width);
+            var (content, contentLines, focusedLine) = BuildContent(model, renderWidth);
 
-            var reserved = CountLines(header, width) + CountLines(footer, width);
+            var reserved = CountLines(header, renderWidth) + CountLines(footer, renderWidth);
             var contentHeight = ViewportState.ContentHeight(height, reserved);
             var viewport = ViewportState.Calculate(contentLines, contentHeight, focusedLine, _offset);
             _offset = viewport.Offset;
 
-            console.Write(new Rows(header, new ViewportRenderable(content, viewport), footer));
+            var frame = new Rows(header, new ViewportRenderable(content, viewport), footer);
+            console.Write(new WidthConstrainedRenderable(frame, renderWidth));
         }
         finally
         {
@@ -93,5 +96,26 @@ internal sealed class SpectreTerminalRenderer(IAnsiConsole console) : ITerminalR
     {
         var options = RenderOptions.Create(console, console.Profile.Capabilities);
         return Segment.SplitLines(renderable.Render(options, width)).Count;
+    }
+
+    internal sealed class WidthConstrainedRenderable(IRenderable content, int width) : Renderable
+    {
+        private readonly int _width = Math.Max(1, width);
+
+        protected override Measurement Measure(RenderOptions options, int maxWidth)
+        {
+            return content.Measure(options, Math.Min(_width, maxWidth));
+        }
+
+        protected override IEnumerable<Segment> Render(RenderOptions options, int maxWidth)
+        {
+            var segments = content.Render(options, Math.Min(_width, maxWidth)).ToList();
+            while (segments.Count > 0 && ReferenceEquals(segments[^1], Segment.LineBreak))
+            {
+                segments.RemoveAt(segments.Count - 1);
+            }
+
+            return segments;
+        }
     }
 }

--- a/code/backend/DD.TerminalClient/TerminalApplication.cs
+++ b/code/backend/DD.TerminalClient/TerminalApplication.cs
@@ -733,7 +733,6 @@ internal sealed class TerminalApplication
             IsSnapshotReloadPending = State.IsSnapshotReloadPending,
             Notification = State.StatusMessage ?? State.Notification,
             ProfileName = _deps.ProfileName,
-            ConnectionUrl = _deps.ConnectionUrl,
             Status = BuildStatus(),
         };
     }

--- a/code/backend/DD.TerminalClient/TerminalDependencies.cs
+++ b/code/backend/DD.TerminalClient/TerminalDependencies.cs
@@ -40,8 +40,6 @@ internal sealed record TerminalDependencies
 
     public required string ProfileName { get; init; }
 
-    public string? ConnectionUrl { get; init; }
-
     // Injectable so retry and timer waits are immediate under test; production uses Task.Delay.
     public Func<TimeSpan, CancellationToken, Task> Delay { get; init; } = Task.Delay;
 

--- a/code/backend/DD.Tests.Unit/TerminalClient/OverviewProjectionTests.cs
+++ b/code/backend/DD.Tests.Unit/TerminalClient/OverviewProjectionTests.cs
@@ -275,8 +275,12 @@ public sealed class OverviewProjectionTests
         Assert.True(cell.HasCollapsedRoutineTasks);
     }
 
-    [Fact]
-    public void Project_CompletedCollapsedRoutines_KeepSummaryWithZeroCount()
+    [Theory]
+    [InlineData(false, false)]
+    [InlineData(true, true)]
+    public void Project_CompletedCollapsedRoutines_FollowCompletedVisibility(
+        bool showCompleted,
+        bool expectedSummary)
     {
         var service = CreateService();
 
@@ -285,14 +289,14 @@ public sealed class OverviewProjectionTests
                 Task("r-done-1", date: Monday, order: 1, type: TerminalTaskType.Routine, completed: true),
                 Task("r-done-2", date: Monday, order: 2, type: TerminalTaskType.Routine, completed: true),
             ],
-            showCompleted: false,
+            showCompleted,
             NoRoutineShown);
 
         var cell = result.Current[0];
         Assert.Empty(cell.Tasks);
         Assert.True(cell.IsEmpty);
         Assert.Equal(0, cell.CollapsedRoutineCount);
-        Assert.True(cell.HasCollapsedRoutineTasks);
+        Assert.Equal(expectedSummary, cell.HasCollapsedRoutineTasks);
     }
 
     [Fact]

--- a/code/backend/DD.Tests.Unit/TerminalClient/OverviewRendererTests.cs
+++ b/code/backend/DD.Tests.Unit/TerminalClient/OverviewRendererTests.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using DD.TerminalClient.Details.Ui;
 using DD.TerminalClient.Domain.Models;
 using DD.TerminalClient.Domain.Navigation;
@@ -21,12 +22,46 @@ public sealed class OverviewRendererTests
     private static readonly DateOnly Monday = new(2024, 11, 4);
 
     [Fact]
-    public void Render_Empty_ShowsEmptyState()
+    public void Render_Empty_ShowsAllFourteenCurrentDays()
     {
         var console = Plain(80);
-        console.Write(TerminalFrame.Render(Vm(Project()), 80));
+        var rendered = OverviewRenderer.Render(Vm(Project()), 80);
+        console.Write(new Rows(rendered.Lines));
 
-        Assert.Contains("No tasks to show", console.Output, StringComparison.Ordinal);
+        Assert.Contains("Current", console.Output, StringComparison.Ordinal);
+        for (var i = 0; i < 14; i++)
+        {
+            Assert.Contains(
+                Monday.AddDays(i).ToString("MM/dd ddd", CultureInfo.InvariantCulture),
+                console.Output,
+                StringComparison.Ordinal);
+        }
+
+        Assert.DoesNotContain("No tasks to show", console.Output, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Render_CurrentDayWithOnlyHiddenCompletedTasks_StillShowsDay()
+    {
+        var projection = ProjectRaw(
+            [Task("done", date: Monday.AddDays(3), completed: true)],
+            showCompleted: false,
+            routineShownDates: new HashSet<DateOnly>());
+        var console = Plain(80);
+
+        console.Write(new Rows(OverviewRenderer.Render(Vm(projection), 80).Lines));
+
+        Assert.Contains("11/07 Thu", console.Output, StringComparison.Ordinal);
+        Assert.DoesNotContain("done", console.Output, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Render_CurrentWeeks_AreSeparatedBySubtleGreyLine()
+    {
+        var rendered = OverviewRenderer.Render(Vm(Project()), 80);
+
+        Assert.Equal("  ------------------------", RenderLine(rendered.Lines[14], 80));
+        Assert.Contains("[2;38;5;8m", Ansi(rendered.Lines[14], 80), StringComparison.Ordinal);
     }
 
     [Fact]
@@ -104,11 +139,12 @@ public sealed class OverviewRendererTests
         Assert.Equal(1, rendered.TaskLines.Single(line => line.Address.Section == OverviewSection.NoDate).LineIndex);
         Assert.Equal(5, mondayLine.LineIndex);
         Assert.Equal(8, tuesdayLine.LineIndex);
-        Assert.Equal(12, rendered.TaskLines.Single(line => line.Address.Section == OverviewSection.Future).LineIndex);
+        Assert.Equal(36, rendered.TaskLines.Single(line => line.Address.Section == OverviewSection.Future).LineIndex);
         Assert.Equal(string.Empty, RenderLine(rendered.Lines[2], 80));
         Assert.Equal(string.Empty, RenderLine(rendered.Lines[6], 80));
-        Assert.Equal(string.Empty, RenderLine(rendered.Lines[9], 80));
-        Assert.Equal(13, rendered.Lines.Count);
+        Assert.Equal("  ------------------------", RenderLine(rendered.Lines[19], 80));
+        Assert.Equal(string.Empty, RenderLine(rendered.Lines[33], 80));
+        Assert.Equal(37, rendered.Lines.Count);
     }
 
     [Fact]
@@ -162,8 +198,11 @@ public sealed class OverviewRendererTests
     public void Render_NonTodayDayHeader_IsBlueWithoutEdgeMarkers()
     {
         var projection = Project(Task("tomorrow", date: Monday.AddDays(1), title: "Later"));
+        var rendered = OverviewRenderer.Render(Vm(projection), 80);
+        var header = rendered.Lines.Single(line =>
+            string.Equals(RenderLine(line, 80), "  11/05 Tue", StringComparison.Ordinal));
 
-        var output = Ansi(new Rows(OverviewRenderer.Render(Vm(projection), 80).Lines), 80);
+        var output = Ansi(header, 80);
 
         Assert.Contains("11/05 Tue", output, StringComparison.Ordinal);
         Assert.DoesNotContain("--", output, StringComparison.Ordinal);
@@ -196,14 +235,14 @@ public sealed class OverviewRendererTests
     }
 
     [Fact]
-    public void Render_CompletedRoutinesCollapsed_ShowsZeroCount()
+    public void Render_CompletedRoutinesCollapsed_ShowsZeroCountWhenCompletedVisible()
     {
         var projection = ProjectRaw(
             [
                 Task("routine-1", date: Monday, completed: true, type: TerminalTaskType.Routine),
                 Task("routine-2", date: Monday, completed: true, type: TerminalTaskType.Routine),
             ],
-            showCompleted: false,
+            showCompleted: true,
             routineShownDates: new HashSet<DateOnly>());
         var console = Plain(80);
         var rendered = new Rows(OverviewRenderer.Render(Vm(projection), 80).Lines);
@@ -387,92 +426,58 @@ public sealed class OverviewRendererTests
     }
 
     [Fact]
-    public void RenderContent_Help_NonProductionProfileShowsConnectionUrl()
+    public void RenderContent_Help_DoesNotShowBackendDetails()
     {
         var status = new TerminalStatus { Kind = TerminalStatusKind.Help };
         var console = Plain(100);
 
         console.Write(TerminalFrame.RenderContent(
-            Vm(Project(), status: status, connectionUrl: "http://localhost:5000/"),
-            100));
-
-        Assert.Contains("Debug", console.Output, StringComparison.Ordinal);
-        Assert.Contains("Server", console.Output, StringComparison.Ordinal);
-        Assert.Contains("http://localhost:5000/", console.Output, StringComparison.Ordinal);
-    }
-
-    [Fact]
-    public void RenderContent_Help_ProductionProfileDoesNotShowDebugSection()
-    {
-        var status = new TerminalStatus { Kind = TerminalStatusKind.Help };
-        var console = Plain(100);
-
-        console.Write(TerminalFrame.RenderContent(
-            Vm(Project(), status: status, profileName: "production"),
+            Vm(Project(), status: status, profileName: "local"),
             100));
 
         Assert.DoesNotContain("Debug", console.Output, StringComparison.Ordinal);
         Assert.DoesNotContain("Server", console.Output, StringComparison.Ordinal);
+        Assert.DoesNotContain("local", console.Output, StringComparison.Ordinal);
     }
 
     [Fact]
-    public void RenderFooter_Offline_ShowsPersistentStatus()
+    public void RenderFooter_DoesNotShowPersistentStatuses()
     {
         var console = Plain(80);
 
-        console.Write(TerminalFrame.RenderFooter(Vm(Project(), offline: true)));
+        console.Write(TerminalFrame.RenderFooter(Vm(
+            Project(),
+            offline: true,
+            hasUnsyncedChanges: true,
+            snapshotReloadPending: true)));
 
-        Assert.Contains("offline", console.Output, StringComparison.Ordinal);
+        Assert.DoesNotContain("offline", console.Output, StringComparison.Ordinal);
+        Assert.DoesNotContain("unsynced", console.Output, StringComparison.Ordinal);
+        Assert.DoesNotContain("stale", console.Output, StringComparison.Ordinal);
     }
 
     [Fact]
-    public void RenderFooter_Unsynced_ShowsIndependentStatus()
+    public void RenderHeader_MultipleProblems_ShowsCompactYellowStatusStrip()
     {
-        var console = Plain(80);
-
-        console.Write(TerminalFrame.RenderFooter(Vm(Project(), hasUnsyncedChanges: true)));
-
-        Assert.Contains("unsynced", console.Output, StringComparison.Ordinal);
-    }
-
-    [Fact]
-    public void RenderFooter_MultipleProblems_ShowsCompactYellowStatusStrip()
-    {
-        var footer = TerminalFrame.RenderFooter(Vm(
+        var header = TerminalFrame.RenderHeader(Vm(
             Project(),
             offline: true,
             hasUnsyncedChanges: true,
             snapshotReloadPending: true));
         var console = Plain(80);
-        console.Write(footer);
-        var ansi = Ansi(footer, 80);
+        console.Write(header);
+        var ansi = Ansi(header, 80);
 
         Assert.Contains("offline unsynced stale", console.Output, StringComparison.Ordinal);
         Assert.Contains("[38;5;11m", ansi, StringComparison.Ordinal);
     }
 
     [Fact]
-    public void RenderHeader_DoesNotRenderConnectionOrSyncStatus()
+    public void RenderHeader_SnapshotReloadPending_ShowsOnlyStaleStatus()
     {
         var console = Plain(80);
 
-        console.Write(TerminalFrame.RenderHeader(Vm(
-            Project(),
-            offline: true,
-            hasUnsyncedChanges: true,
-            snapshotReloadPending: true)));
-
-        Assert.DoesNotContain("offline", console.Output, StringComparison.OrdinalIgnoreCase);
-        Assert.DoesNotContain("unsynced", console.Output, StringComparison.OrdinalIgnoreCase);
-        Assert.DoesNotContain("stale", console.Output, StringComparison.OrdinalIgnoreCase);
-    }
-
-    [Fact]
-    public void RenderFooter_SnapshotReloadPending_ShowsOnlyStaleStatus()
-    {
-        var console = Plain(80);
-
-        console.Write(TerminalFrame.RenderFooter(Vm(Project(), snapshotReloadPending: true)));
+        console.Write(TerminalFrame.RenderHeader(Vm(Project(), snapshotReloadPending: true)));
 
         Assert.Contains("stale", console.Output, StringComparison.Ordinal);
         Assert.DoesNotContain("retried", console.Output, StringComparison.OrdinalIgnoreCase);
@@ -489,14 +494,26 @@ public sealed class OverviewRendererTests
     }
 
     [Fact]
-    public void RenderHeader_ShowsProfileAndCompletedIndicator()
+    public void RenderHeader_ShowsNonProductionProfileWithoutCompletedIndicator()
     {
         var console = Plain(80);
 
-        console.Write(TerminalFrame.RenderHeader(Vm(Project(), profileName: "production", showCompleted: true)));
+        console.Write(TerminalFrame.RenderHeader(Vm(Project(), profileName: "test", showCompleted: true)));
 
-        Assert.Contains("production", console.Output, StringComparison.Ordinal);
-        Assert.Contains("completed shown", console.Output, StringComparison.Ordinal);
+        Assert.Contains("test", console.Output, StringComparison.Ordinal);
+        Assert.DoesNotContain("completed shown", console.Output, StringComparison.Ordinal);
+    }
+
+    [Theory]
+    [InlineData("production")]
+    [InlineData("Production")]
+    public void RenderHeader_HidesProductionProfile(string profileName)
+    {
+        var console = Plain(80);
+
+        console.Write(TerminalFrame.RenderHeader(Vm(Project(), profileName: profileName)));
+
+        Assert.DoesNotContain(profileName, console.Output, StringComparison.OrdinalIgnoreCase);
     }
 
     private static OverviewProjection Project(params TerminalTask[] tasks)
@@ -522,7 +539,6 @@ public sealed class OverviewRendererTests
         bool offline = false,
         string? notification = null,
         string profileName = "",
-        string? connectionUrl = null,
         bool hasUnsyncedChanges = false,
         bool snapshotReloadPending = false,
         bool showCompleted = false)
@@ -538,7 +554,6 @@ public sealed class OverviewRendererTests
             IsSnapshotReloadPending = snapshotReloadPending,
             Notification = notification,
             ProfileName = profileName,
-            ConnectionUrl = connectionUrl,
             Status = status ?? new TerminalStatus(),
         };
     }

--- a/code/backend/DD.Tests.Unit/TerminalClient/SpectreTerminalRendererTests.cs
+++ b/code/backend/DD.Tests.Unit/TerminalClient/SpectreTerminalRendererTests.cs
@@ -1,6 +1,7 @@
 using DD.TerminalClient;
 using DD.TerminalClient.Details.Ui;
 using DD.TerminalClient.Domain.Application;
+using Spectre.Console;
 using Spectre.Console.Testing;
 using Xunit;
 
@@ -30,5 +31,29 @@ public sealed class SpectreTerminalRendererTests
         var end = console.Output.IndexOf("\u001b[?2026l", StringComparison.Ordinal);
         Assert.True(begin >= 0);
         Assert.True(end > begin);
+    }
+
+    [Fact]
+    public void WidthConstrainedRenderable_LeavesRightmostColumnUnused()
+    {
+        var console = new TestConsole();
+        console.Profile.Width = 10;
+
+        console.Write(new SpectreTerminalRenderer.WidthConstrainedRenderable(new Rule(), width: 9));
+
+        Assert.Equal(9, Assert.Single(console.Lines).Length);
+    }
+
+    [Fact]
+    public void WidthConstrainedRenderable_OmitsTrailingLineBreak()
+    {
+        var console = new TestConsole();
+        console.Profile.Width = 10;
+
+        console.Write(new SpectreTerminalRenderer.WidthConstrainedRenderable(
+            new Rows(new Text("header"), new Text("footer")),
+            width: 9));
+
+        Assert.False(console.Output.EndsWith('\n'));
     }
 }

--- a/code/backend/DD.Tests.Unit/TerminalClient/TerminalApplicationTests.cs
+++ b/code/backend/DD.Tests.Unit/TerminalClient/TerminalApplicationTests.cs
@@ -400,11 +400,11 @@ public sealed class TerminalApplicationTests
         await WaitForAsync(
             () => harness.LastModel().IsOffline && harness.LastModel().HasUnsyncedChanges,
             "combined offline and unsynced state");
-        Assert.Contains("offline unsynced", RenderFooter(harness.LastModel()), StringComparison.Ordinal);
+        Assert.Contains("offline unsynced", RenderHeader(harness.LastModel()), StringComparison.Ordinal);
 
         harness.Enqueue(Key('?'));
         await WaitForAsync(() => harness.LastModel().Status.Kind == TerminalStatusKind.Help, "help opened");
-        Assert.Contains("offline unsynced", RenderFooter(harness.LastModel()), StringComparison.Ordinal);
+        Assert.Contains("offline unsynced", RenderHeader(harness.LastModel()), StringComparison.Ordinal);
 
         harness.Enqueue(ApplicationEvent.RetryTick);
         await WaitForAsync(() => harness.Tasks.SavedBatches.Count >= 2, "save retried");
@@ -820,12 +820,12 @@ public sealed class TerminalApplicationTests
         }
     }
 
-    private static string RenderFooter(TerminalViewModel model)
+    private static string RenderHeader(TerminalViewModel model)
     {
         var console = new TestConsole();
         console.Profile.Width = 140;
         console.Profile.Height = 40;
-        console.Write(TerminalFrame.RenderFooter(model));
+        console.Write(TerminalFrame.RenderHeader(model));
         return console.Output;
     }
 

--- a/code/backend/DD.Tests.Unit/TerminalClient/ViewportRenderableTests.cs
+++ b/code/backend/DD.Tests.Unit/TerminalClient/ViewportRenderableTests.cs
@@ -132,7 +132,8 @@ public sealed class ViewportRenderableTests
     [Fact]
     public void Render_BottomFocus_ClipsTopAndShowsMoreAbove()
     {
-        var projection = Project(NoDateTasks(25));
+        var projection = Project(
+            [.. NoDateTasks(24), Task("u24", date: Monday.AddDays(13), title: "T24")]);
         var (viewport, _, _) = Build(Vm(projection, focus: FocusFor(projection, "u24")), width: 120, viewportHeight: 10);
         var console = Plain(120);
 
@@ -140,8 +141,6 @@ public sealed class ViewportRenderableTests
         var output = console.Output;
 
         Assert.Contains("T24", output, StringComparison.Ordinal);
-        Assert.Contains("T17", output, StringComparison.Ordinal);
-        Assert.DoesNotContain("T16", output, StringComparison.Ordinal);
         Assert.DoesNotContain("T00", output, StringComparison.Ordinal);
         Assert.DoesNotContain("No Date", output, StringComparison.Ordinal);
         Assert.Contains("more above", output, StringComparison.Ordinal);
@@ -226,7 +225,7 @@ public sealed class ViewportRenderableTests
     public void Render_ContentShorterThanViewport_ShowsEverythingWithoutIndicators()
     {
         var projection = Project(NoDateTasks(3));
-        var (viewport, state, _) = Build(Vm(projection), width: 120, viewportHeight: 12);
+        var (viewport, state, _) = Build(Vm(projection), width: 120, viewportHeight: 40);
         var console = Plain(120);
 
         console.Write(viewport);
@@ -267,7 +266,7 @@ public sealed class ViewportRenderableTests
     {
         var projection = Project(NoDateTasks(25));
 
-        var (tall, tallState, _) = Build(Vm(projection), width: 120, viewportHeight: 30);
+        var (tall, tallState, _) = Build(Vm(projection), width: 120, viewportHeight: 60);
         var tallConsole = Plain(120);
         tallConsole.Write(tall);
         Assert.False(tallState.Scrollable);
@@ -417,7 +416,12 @@ public sealed class ViewportRenderableTests
 
     private static TaskFocus FocusFor(OverviewProjection projection, string uid)
     {
-        foreach (var overviewTask in projection.NoDate.Tasks)
+        var days = new List<OverviewDay> { projection.NoDate };
+        days.AddRange(projection.Overdue);
+        days.AddRange(projection.Current);
+        days.AddRange(projection.Future);
+
+        foreach (var overviewTask in days.SelectMany(day => day.Tasks))
         {
             if (string.Equals(overviewTask.Task.Uid, uid, StringComparison.Ordinal))
             {
@@ -425,7 +429,7 @@ public sealed class ViewportRenderableTests
             }
         }
 
-        throw new InvalidOperationException($"Task {uid} not found in No Date section");
+        throw new InvalidOperationException($"Task {uid} not found");
     }
 
     private static TestConsole Plain(int width)
@@ -443,13 +447,17 @@ public sealed class ViewportRenderableTests
         return console.Output;
     }
 
-    private static TerminalTask Task(string uid, int order = 0, string title = "Task")
+    private static TerminalTask Task(
+        string uid,
+        int order = 0,
+        string title = "Task",
+        DateOnly? date = null)
     {
         return new TerminalTask
         {
             Uid = uid,
             Title = title,
-            Date = null,
+            Date = date,
             Time = null,
             Order = order,
             Completed = false,


### PR DESCRIPTION
- Keep the fixed header visible and centralize environment and sync statuses there
- Always render both Current weeks with a subtle week separator
- Align completed-task and collapsed Routine visibility behavior